### PR TITLE
Do service start only after everything else.

### DIFF
--- a/openvpn/init.sls
+++ b/openvpn/init.sls
@@ -10,14 +10,6 @@ openvpn_pkgs:
       - {{pkg }}
       {% endfor %}
 
-# Ensure openvpn service is running and autostart is enabled
-openvpn_service:
-  service.running:
-    - name: {{ map.service }}
-    - enable: True
-    - require:
-      - pkg: openvpn_pkgs
-
 # Generate diffie hellman files
 {% for dh in map.dh_files %}
 openvpn_create_dh_{{ dh }}:
@@ -57,3 +49,12 @@ openvpn_config_{{name}}:
     - watch_in:
       - service: openvpn_service
 {% endfor %}
+
+# Ensure openvpn service is running and autostart is enabled
+openvpn_service:
+  service.running:
+    - name: {{ map.service }}
+    - enable: True
+    - require:
+      - pkg: openvpn_pkgs
+


### PR DESCRIPTION
Right now for modern salt openvpn service start happens before generation of Diffie–Hellman parameters and will always fail.

This changeset addresses the problem.

Tested with vagrant.