### PR TITLE
Extended the configurable options

### DIFF
--- a/openvpn/files/server.jinja
+++ b/openvpn/files/server.jinja
@@ -1,8 +1,13 @@
 # OpenVPN server configuration '{{ name }}'
-# Managed by salt !!!
+# Managed by Salt
+# Template: {{ source }}
 
 {%- if config.local is defined %}
 local {{ config.local }}
+{%- endif %}
+
+{%- if config.auth is defined %}
+auth {{ config.auth }}
 {%- endif %}
 
 {%- if config.port is defined %}
@@ -11,6 +16,13 @@ port {{ config.port }}
 port 1194
 {%- endif %}
 
+{%- if config.port_share is defined %}
+port-share {{ config.port_share }}
+{%- endif %}
+
+{%- if config.daemon is defined and config.daemon == True %}
+daemon
+{%- endif %}
 
 {%- if config.proto is defined %}
 proto {{ config.proto }}
@@ -156,4 +168,18 @@ verb 3
 
 {%- if config.mute is defined %}
 mute {{ config.mute }}
+{%- endif %}
+
+{%- if config.ccd_exclusive is defined and config.ccd_exclusive == True %}
+ccd-exclusive
+{%- endif %}
+
+{%- if config.username_as_common_name is defined and config.username_as_common_name == True %}
+username-as-common-name
+{%- endif %}
+
+{%- if config.plugins is defined %}
+{%- for plugin in config.plugins %}
+plugin "{{ plugin }}"
+{%- endfor %}
 {%- endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -37,7 +37,7 @@ openvpn:
       tls_auth:
       ciphers:
         - BF-CBC
-        - AES-128-CBC  
+        - AES-128-CBC
       comp_lzo:
       max_clients: 100
       user: nobody
@@ -49,6 +49,15 @@ openvpn:
       log_append: openvpn.log
       verb: 3
       mute: 20
+    myserver3:
+      daemon:
+      port: 443
+      port_share: '127.0.0.1 4430'
+      ccd_exclusive:
+      auth: SHA1
+      username_as_common_name:
+      plugins:
+        - '/usr/lib/openvpn/radiusplugin.so /etc/openvpn/radiusplugin.cnf'
   client:
     myclient1:
       remote:
@@ -81,7 +90,7 @@ openvpn:
       tls_auth:
       ciphers:
         - BF-CBC
-        - AES-128-CBC  
-      comp_lzo:    
+        - AES-128-CBC
+      comp_lzo:
       verb: 3
       mute: 20


### PR DESCRIPTION
The configuration was missing a few key pieces I needed. Instead of simply overriding the file I'm sharing my changes since it may be helpful for others as well.

I have added the following options:
* Auth
* Port-Share (to be able to share a webserver on the same port and provide VPN over 443)
* Deamon
* CCD-Exclusive
* Username-As-Common-Name
* Plugins (e.g. Radius, LDAP)

I also added `{{ source }}` in the template to make it easier to find on which template the generated configuration was based on.