### PR TITLE
Add support for optional pillar deployment of certificates & keys.

### DIFF
--- a/openvpn/init.sls
+++ b/openvpn/init.sls
@@ -56,6 +56,17 @@ openvpn_config_{{ type }}_{{ name }}_cert_file:
       - service: openvpn_service
 {% endif %}
 
+{% if config.key is defined and config.key_content is defined %}
+# Deploy {{ type }} {{ name }} private key file
+openvpn_config_{{ type }}_{{ name }}_key_file:
+  file.managed:
+    - name: {{ map.conf_dir }}/{{ config.key }}
+    - contents_pillar: openvpn:{{ type }}:{{ name }}:key_content
+    - makedirs: True
+    - watch_in:
+      - service: openvpn_service
+{% endif %}
+
 {% endfor %}
 {% endfor %}
 

--- a/openvpn/init.sls
+++ b/openvpn/init.sls
@@ -18,12 +18,13 @@ openvpn_create_dh_{{ dh }}:
     - creates: {{ map.conf_dir }}/dh{{ dh }}.pem
 {% endfor %}
 
-# Deploy server config files
-{% for name, config in salt['pillar.get']('openvpn:server', {}).iteritems() %}
-openvpn_config_{{name}}:
+{% for type, names in salt['pillar.get']('openvpn', {}).iteritems() %}
+{% for name, config in names.iteritems() %}
+# Deploy {{ type }} {{ name }} config files
+openvpn_config_{{ type }}_{{ name }}:
   file.managed:
     - name: {{ map.conf_dir }}/{{name}}.conf
-    - source: salt://openvpn/files/server.jinja
+    - source: salt://openvpn/files/{{ type }}.jinja
     - template: jinja
     - context:
         name: {{ name }}
@@ -33,21 +34,6 @@ openvpn_config_{{name}}:
     - watch_in:
       - service: openvpn_service
 {% endfor %}
-
-# Deploy client config files
-{% for name, config in salt['pillar.get']('openvpn:client', {}).iteritems() %}
-openvpn_config_{{name}}:
-  file.managed:
-    - name: {{ map.conf_dir }}/{{name}}.conf
-    - source: salt://openvpn/files/client.jinja
-    - template: jinja
-    - context:
-        name: {{ name }}
-        config: {{ config }}
-        user: {{ map.user }}
-        group: {{ map.group }}
-    - watch_in:
-      - service: openvpn_service
 {% endfor %}
 
 # Ensure openvpn service is running and autostart is enabled

--- a/openvpn/init.sls
+++ b/openvpn/init.sls
@@ -45,6 +45,17 @@ openvpn_config_{{ type }}_{{ name }}_ca_file:
       - service: openvpn_service
 {% endif %}
 
+{% if config.cert is defined and config.cert_content is defined %}
+# Deploy {{ type }} {{ name }} certificate file
+openvpn_config_{{ type }}_{{ name }}_cert_file:
+  file.managed:
+    - name: {{ map.conf_dir }}/{{ config.cert }}
+    - contents_pillar: openvpn:{{ type }}:{{ name }}:cert_content
+    - makedirs: True
+    - watch_in:
+      - service: openvpn_service
+{% endif %}
+
 {% endfor %}
 {% endfor %}
 

--- a/openvpn/init.sls
+++ b/openvpn/init.sls
@@ -67,6 +67,17 @@ openvpn_config_{{ type }}_{{ name }}_key_file:
       - service: openvpn_service
 {% endif %}
 
+{% if config.tls_auth is defined and config.ta_content is defined %}
+# Deploy {{ type }} {{ name }} TLS key file
+openvpn_config_{{ type }}_{{ name }}_tls_auth_file:
+  file.managed:
+    - name: {{ map.conf_dir }}/{{ config.tls_auth.split()[0] }}
+    - contents_pillar: openvpn:{{ type }}:{{ name }}:ta_content
+    - makedirs: True
+    - watch_in:
+      - service: openvpn_service
+{% endif %}
+
 {% endfor %}
 {% endfor %}
 

--- a/openvpn/init.sls
+++ b/openvpn/init.sls
@@ -38,7 +38,7 @@ openvpn_config_{{ type }}_{{ name }}:
 # Deploy {{ type }} {{ name }} CA file
 openvpn_config_{{ type }}_{{ name }}_ca_file:
   file.managed:
-    - name: {{ map.conf_dir }}/{{ config.ca }}
+    - name: {{ config.ca }}
     - contents_pillar: openvpn:{{ type }}:{{ name }}:ca_content
     - makedirs: True
     - watch_in:
@@ -49,7 +49,7 @@ openvpn_config_{{ type }}_{{ name }}_ca_file:
 # Deploy {{ type }} {{ name }} certificate file
 openvpn_config_{{ type }}_{{ name }}_cert_file:
   file.managed:
-    - name: {{ map.conf_dir }}/{{ config.cert }}
+    - name: {{ config.cert }}
     - contents_pillar: openvpn:{{ type }}:{{ name }}:cert_content
     - makedirs: True
     - watch_in:
@@ -60,7 +60,7 @@ openvpn_config_{{ type }}_{{ name }}_cert_file:
 # Deploy {{ type }} {{ name }} private key file
 openvpn_config_{{ type }}_{{ name }}_key_file:
   file.managed:
-    - name: {{ map.conf_dir }}/{{ config.key }}
+    - name: {{ config.key }}
     - contents_pillar: openvpn:{{ type }}:{{ name }}:key_content
     - makedirs: True
     - watch_in:
@@ -71,7 +71,7 @@ openvpn_config_{{ type }}_{{ name }}_key_file:
 # Deploy {{ type }} {{ name }} TLS key file
 openvpn_config_{{ type }}_{{ name }}_tls_auth_file:
   file.managed:
-    - name: {{ map.conf_dir }}/{{ config.tls_auth.split()[0] }}
+    - name: {{ config.tls_auth.split()[0] }}
     - contents_pillar: openvpn:{{ type }}:{{ name }}:ta_content
     - makedirs: True
     - watch_in:

--- a/openvpn/init.sls
+++ b/openvpn/init.sls
@@ -33,6 +33,18 @@ openvpn_config_{{ type }}_{{ name }}:
         group: {{ map.group }}
     - watch_in:
       - service: openvpn_service
+
+{% if config.ca is defined and config.ca_content is defined %}
+# Deploy {{ type }} {{ name }} CA file
+openvpn_config_{{ type }}_{{ name }}_ca_file:
+  file.managed:
+    - name: {{ map.conf_dir }}/{{ config.ca }}
+    - contents_pillar: openvpn:{{ type }}:{{ name }}:ca_content
+    - makedirs: True
+    - watch_in:
+      - service: openvpn_service
+{% endif %}
+
 {% endfor %}
 {% endfor %}
 

--- a/pillar.example
+++ b/pillar.example
@@ -21,8 +21,20 @@ openvpn:
       dev: tun
       dev_node:
       ca: /path/to/mycacert.pem
+      ca_content: |
+        -----BEGIN CERTIFICATE-----
+        ...
+        -----END CERTIFICATE-----
       cert: /path/to/mycert.pem
+      cert_content: |
+        -----BEGIN CERTIFICATE-----
+        ...
+        -----END CERTIFICATE-----
       key: /path/to/mykey.pem
+      key_content: |
+        -----BEGIN PRIVATE KEY-----
+        ...
+        -----END PRIVATE KEY-----
       dh: dh1024.pem
       server: '10.8.0.0 255.255.255.0'
       ifconfig_pool_persist: ipp.txt
@@ -36,7 +48,11 @@ openvpn:
       client_to_client: False
       duplicate_cn: False
       keepalive: '10 120'
-      tls_auth:
+      tls_auth: /path/to/tls.key 0
+      ta_content: |
+        -----BEGIN OpenVPN Static key V1-----
+        ...
+        -----END OpenVPN Static key V1-----
       ciphers:
         - BF-CBC
         - AES-128-CBC
@@ -86,10 +102,26 @@ openvpn:
       http_proxy: 'proxy-server proxy-port'
       mute_replay_warnings:
       ca: /path/to/mycacert.pem
+      ca_content: |
+        -----BEGIN CERTIFICATE-----
+        ...
+        -----END CERTIFICATE-----
       cert: /path/to/mycert.pem
+      cert_content: |
+        -----BEGIN CERTIFICATE-----
+        ...
+        -----END CERTIFICATE-----
       key: /path/to/mykey.pem
+      key_content: |
+        -----BEGIN PRIVATE KEY-----
+        ...
+        -----END PRIVATE KEY-----
       ns_cert_type: server
-      tls_auth:
+      tls_auth: /path/to/tls.key 0
+      ta_content: |
+        -----BEGIN OpenVPN Static key V1-----
+        ...
+        -----END OpenVPN Static key V1-----
       ciphers:
         - BF-CBC
         - AES-128-CBC


### PR DESCRIPTION
**Summary of Changes**
- Reduce redundancy of configuring server and client separately. 
- Add support for optionally deploying CA cert file.
- Add support for optionally deploying certificate file.
- Add support for optionally deploying private key file.
- Add support for optionally deploying TLA key file.
- Path to cert\keys files is absolute in pillar