### PR TITLE
It's not always useful to have quotes around the plugin option.

### DIFF
--- a/openvpn/files/server.jinja
+++ b/openvpn/files/server.jinja
@@ -186,7 +186,7 @@ username-as-common-name
 
 {%- if config.plugins is defined %}
 {%- for plugin in config.plugins %}
-plugin "{{ plugin }}"
+plugin {{ plugin }}
 {%- endfor %}
 {%- endif %}
 


### PR DESCRIPTION
e.g. https://www.duosecurity.com/docs/openvpn#configure-the-server

Some plugins expect the extra arguments. When in quotes openvpn fails to start complaining that it can't file the arguments as files.

This may apply to other options too.