### PR TITLE
Adding client-cert-not-required option to server config

### DIFF
--- a/openvpn/files/server.jinja
+++ b/openvpn/files/server.jinja
@@ -213,3 +213,7 @@ reneg-sec {{ config.reneg_sec }}
 {%- if config.tun_mtu is defined %}
 tun-mtu {{ config.tun_mtu }}
 {%- endif %}
+
+{%- if config.client_cert_not_required is defined %}
+client-cert-not-required
+{%- endif %}


### PR DESCRIPTION
While this settings is discourged in the docs, it's very useful when
configuring OpenVPN for LDAP authentication.