### PR TITLE
Add support for multiple openvpn services if the OS is using systemd

### DIFF
--- a/openvpn/init.sls
+++ b/openvpn/init.sls
@@ -20,10 +20,12 @@ openvpn_create_dh_{{ dh }}:
 
 
 # Ensure openvpn service is running and autostart is enabled
+# If OS is running systemd then not use this generic service
+{% if not salt['grains.has_value']('systemd') %}
 openvpn_service:
   service.running:
     - name: {{ map.service }}
     - enable: True
     - require:
       - pkg: openvpn_pkgs
-
+{% endif %}


### PR DESCRIPTION
On distributions using systemd, the openvpn init service is split in a service for each config file. For example: office.conf and sitetosite.conf will have openvpn@office and openvpn@sitetosite. In this case each service can be handled (start, reboot, stop) independently from each other.

To check if a OS uses systemd I use the grains item "systemd" with the has_value method. Now the service is tied with the config name so I created a new service state in the config.sls file. Last thing was conditioning the requisites (watch_in) for only the new services or the general one in case that systemd is not present.

I've tested the changes in Ubuntu 14.04 and 16.04 and both works. Maybe the implementation could be better but I'm sending the pull request to have the functionality right now.
