### PR TITLE
Status file should have root as owner

### DIFF
--- a/openvpn/config.sls
+++ b/openvpn/config.sls
@@ -123,8 +123,6 @@ openvpn_{{ type }}_{{ name }}_status_file:
   file.managed:
     - name: {{ config.status }}
     - makedirs: True
-    - user: {% if config.user is defined %}{{ config.user }}{% else %}{{ map.user }}{% endif %}
-    - group: {% if config.group is defined %}{{ config.group }}{% else %}{{ map.group }}{% endif %}
     - watch_in:
 {%- if map.multi_services %}
       - service: openvpn_{{name}}_service


### PR DESCRIPTION
Status file should have root username not the user that openvpn is run with.
Ubuntu cannot start openvpn with root permissions

Feb 10 06:58:17 openvpn-us-west-2 ovpn-tcp[9488]: Options error: --status fails with '/etc/openvpn/openvpn-status-tcp.log': Permission denied

After chown root.root - everything works fine.
if i delete that file, openvpn is creating new - owned by root (even if openvpn is started by user nobody)