### PR TITLE
Creation of DH params should depend on openvpn package installation

### DIFF
--- a/openvpn/init.sls
+++ b/openvpn/init.sls
@@ -19,4 +19,6 @@ openvpn_create_dh_{{ dh }}:
   cmd.run:
     - name: openssl dhparam -out {{ map.conf_dir }}/dh{{ dh }}.pem {{ dh }}
     - creates: {{ map.conf_dir }}/dh{{ dh }}.pem
+    - require:
+      - pkg: openvpn_pkgs
 {% endfor %}


### PR DESCRIPTION
Encountered an issue when testing the formula where the package installation failed but the dhparam creation continued. It then failed because openssl couldn't write to the default nonexistent directory `/etc/openvpn/`