### PR TITLE
Removing duplicate config._append block in `server.jinja`

### DIFF
--- a/openvpn/files/server.jinja
+++ b/openvpn/files/server.jinja
@@ -129,9 +129,3 @@ auth-user-pass-verify {{ config.auth_user_pass_verify }}
 setenv {{ setenv }}
 {% endfor %}
 {% endif %}
-
-{%- if config._append is defined %}
-{%-   for data in config._append %}
-{{ data }}
-{%-   endfor %}
-{%- endif %}


### PR DESCRIPTION
# What
Removing the block that iterates over `_append` in `server.jinja`.

# Why
This block is already present in `common_opts.jinja` (https://github.com/saltstack-formulas/openvpn-formula/blob/master/openvpn/files/common_opts.jinja#L211-L216) and doesn't need to appear twice.

# Misc
If there **_is_** a reason for having this block in both files, then there should be separate `_append` definitions, or some other way to separate these.