### PR TITLE
Adding `tls-crypt` support

### DIFF
--- a/openvpn/config.sls
+++ b/openvpn/config.sls
@@ -89,17 +89,23 @@ openvpn_config_{{ type }}_{{ name }}_passwd_file:
       - service: {{ service_id }}
 {% endif %}
 
-{% if config.ta_content is defined %}
+{% if config.ta_content is defined and config.tls_crypt is defined %}
 # Deploy {{ type }} {{ name }} TLS key file
-  {% if config.tls_auth is defined and config.tls_crypt is not defined %}
-openvpn_config_{{ type }}_{{ name }}_tls_auth_file:
-  file.managed:
-    - name: {{ config.tls_auth.split()[0] }}
-  {% elif config.tls_crypt is defined and config.tls_auth is not defined %}
 openvpn_config_{{ type }}_{{ name }}_tls_crypt_file:
   file.managed:
     - name: {{ config.tls_crypt.split()[0] }}
-  {% endif %}
+    - contents_pillar: openvpn:{{ type }}:{{ name }}:ta_content
+    - makedirs: True
+    - mode: 600
+    - user: {% if config.user is defined %}{{ config.user }}{% else %}{{ map.user }}{% endif %}
+    - group: {% if config.group is defined %}{{ config.group }}{% else %}{{ map.group }}{% endif %}
+    - watch_in:
+      - service: {{ service_id }}
+{% elif config.ta_content is defined and config.tls_auth is defined %}
+# Deploy {{ type }} {{ name }} TLS key file
+openvpn_config_{{ type }}_{{ name }}_tls_auth_file:
+  file.managed:
+    - name: {{ config.tls_auth.split()[0] }}
     - contents_pillar: openvpn:{{ type }}:{{ name }}:ta_content
     - makedirs: True
     - mode: 600

--- a/openvpn/config.sls
+++ b/openvpn/config.sls
@@ -89,11 +89,17 @@ openvpn_config_{{ type }}_{{ name }}_passwd_file:
       - service: {{ service_id }}
 {% endif %}
 
-{% if config.tls_auth is defined and config.ta_content is defined %}
+{% if config.ta_content is defined %}
 # Deploy {{ type }} {{ name }} TLS key file
+  {% if config.tls_auth is defined and config.tls_crypt is not defined %}
 openvpn_config_{{ type }}_{{ name }}_tls_auth_file:
   file.managed:
     - name: {{ config.tls_auth.split()[0] }}
+  {% elif config.tls_crypt is defined and config.tls_auth is not defined %}
+openvpn_config_{{ type }}_{{ name }}_tls_crypt_file:
+  file.managed:
+    - name: {{ config.tls_crypt.split()[0] }}
+  {% endif %}
     - contents_pillar: openvpn:{{ type }}:{{ name }}:ta_content
     - makedirs: True
     - mode: 600

--- a/openvpn/files/common_opts.jinja
+++ b/openvpn/files/common_opts.jinja
@@ -135,8 +135,12 @@ dh {{ config.dh }}
 dh dh1024.pem
 {%- endif %}
 
-{%- if config.tls_auth is defined %}
+{%- if config.tls_auth is defined and config.tls_crypt is not defined %}
 tls-auth {{ config.tls_auth }}
+{%- endif %}
+
+{%- if config.tls_crypt is defined and config.tls_auth is not defined %}
+tls-crypt {{ config.tls_crypt }}
 {%- endif %}
 
 {%- if config.reneg_sec is defined %}

--- a/openvpn/files/common_opts.jinja
+++ b/openvpn/files/common_opts.jinja
@@ -135,12 +135,10 @@ dh {{ config.dh }}
 dh dh1024.pem
 {%- endif %}
 
-{%- if config.tls_auth is defined and config.tls_crypt is not defined %}
-tls-auth {{ config.tls_auth }}
-{%- endif %}
-
-{%- if config.tls_crypt is defined and config.tls_auth is not defined %}
+{%- if config.ta_content is defined and config.tls_crypt is defined %}
 tls-crypt {{ config.tls_crypt }}
+{%- elif config.ta_content is defined and config.tls_auth is defined %}
+tls-auth {{ config.tls_auth }}
 {%- endif %}
 
 {%- if config.reneg_sec is defined %}


### PR DESCRIPTION
# What
Adding support for the `tls-crypt` option enabled after OpenVPN 2.4.0+

# Why
Currently the formula does not have this option, even though the formula **_does_** have support for placing a static key with `tls-auth`.

# Misc
The options `tls-crypt` and `tls-auth` are mutually exclusive, so checks must exist for the presence of the other type: https://forums.openvpn.net/viewtopic.php?t=23076