### PR TITLE
Feature/more options

### DIFF
--- a/openvpn/config.sls
+++ b/openvpn/config.sls
@@ -129,6 +129,20 @@ openvpn_config_{{ type }}_{{ name }}_secret_file:
       - service: {{ service_id }}
 {% endif %}
 
+{% if config.auth_user_pass is defined and config.auth_user_pass_content is defined %}
+# Deploy {{ type }} {{ name }} auth_user_pass file
+openvpn_config_{{ type }}_{{ name }}_auth_user_pass_file:
+  file.managed:
+    - name: {{ config.auth_user_pass.split()[0] }}
+    - contents_pillar: openvpn:{{ type }}:{{ name }}:auth_user_pass_content
+    - makedirs: True
+    - mode: 600
+    - user: {% if config.user is defined %}{{ config.user }}{% else %}{{ map.user }}{% endif %}
+    - group: {% if config.group is defined %}{{ config.group }}{% else %}{{ map.group }}{% endif %}
+    - watch_in:
+      - service: {{ service_id }}
+{% endif %}
+
 {% if config.status is defined %}
 # Ensure status file exists and is writeable
 openvpn_{{ type }}_{{ name }}_status_file:

--- a/openvpn/files/client.jinja
+++ b/openvpn/files/client.jinja
@@ -6,6 +6,10 @@ client
 
 {% include 'openvpn/files/common_opts.jinja' %}
 
+{%- if config.pull is defined %}
+pull
+{% endif %}
+
 {%- if not (config.tls_client is defined and config.tls_client == False) %}
 tls-client
 {%- endif %}
@@ -30,3 +34,6 @@ http-proxy-retry
 http-proxy {{ config.http_proxy }}
 {%- endif %}
 
+{%- if config.auth_user_pass is defined %}
+auth-user-pass {{ config.auth_user_pass }}
+{%- endif %}

--- a/openvpn/files/common_opts.jinja
+++ b/openvpn/files/common_opts.jinja
@@ -242,6 +242,12 @@ route-delay {{ config.route_delay }}
 route-nopull
 {% endif %}
 
+{%- if config.route is defined %}
+{%- for route in config.route %}
+route {{ route }}
+{%- endfor %}
+{%- endif %}
+
 {%- if config.fragment is defined %}
 fragment {{ config.fragment }}
 {% endif %}

--- a/openvpn/files/common_opts.jinja
+++ b/openvpn/files/common_opts.jinja
@@ -222,3 +222,42 @@ up-restart
 auth {{ config.auth }}
 {%- endif %}
 
+{%- if config.fast_io is defined %}
+fast-io
+{%- endif %}
+
+{%- if config.key_direction is defined %}
+key-direction {{ config.key_direction }}
+{% endif %}
+
+{%- if config.route_method is defined %}
+route-method {{ config.route_method }}
+{% endif %}
+
+{%- if config.route_delay is defined %}
+route-delay {{ config.route_delay }}
+{% endif %}
+
+{%- if config.route_nopull is defined %}
+route-nopull
+{% endif %}
+
+{%- if config.fragment is defined %}
+fragment {{ config.fragment }}
+{% endif %}
+
+{%- if config.mssfix is defined %}
+mssfix {{ config.mssfix }}
+{% endif %}
+
+{%- if config.keysize is defined %}
+keysize {{ config.keysize }}
+{% endif %}
+
+{%- if config.sndbuf is defined %}
+sndbuf {{ config.sndbuf }}
+{% endif %}
+
+{%- if config.rcvbuf is defined %}
+rcvbuf {{ config.rcvbuf }}
+{% endif %}

--- a/openvpn/files/server.jinja
+++ b/openvpn/files/server.jinja
@@ -60,12 +60,6 @@ push "{{ push }}"
 {%- endfor %}
 {%- endif %}
 
-{%- if config.route is defined %}
-{%- for route in config.route %}
-route {{ route }}
-{%- endfor %}
-{%- endif %}
-
 {%- if config.client_config_dir is defined %}
 client-config-dir {{ config.client_config_dir }}
 {%- endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -204,6 +204,8 @@ openvpn:
       sndbuf: 524288
       rcvbuf: 524288
       route_nopull:
+      route:
+        - "8.8.8.8 255.255.255.255 net_gateway"
 
   ifconfig_pool_persist:
     ipp.txt:

--- a/pillar.example
+++ b/pillar.example
@@ -53,6 +53,7 @@ openvpn:
       server_bridge:
       push:
         - "route 192.168.10.0 255.255.255.0"
+      route_nopull:
       route:
         - "192.168.11.0 255.255.255.0"
       client_config_dir: clients
@@ -187,6 +188,23 @@ openvpn:
         - script-security 2
         - up 'echo up'
         - down 'echo down'
+      auth_user_pass: /path/to/auth.txt
+      auth_user_pass_content: |
+        user
+        password
+      fast_io:
+      pull:
+      tls-client:
+      key-direction: 1
+      route-method: exe
+      route-delay: 2
+      fragment: 1300
+      mssfix: 1450
+      keysize: 256
+      sndbuf: 524288
+      rcvbuf: 524288
+      route_nopull:
+
   ifconfig_pool_persist:
     ipp.txt:
       somehostname: 192.168.51.2


### PR DESCRIPTION
This PR adds the following options;

- `auth_user_pass`
- `auth_user_pass_content`
- `fast_io`
- `fragment`
- `key-direction`
- `keysize`
- `mssfix`
- `pull`
- `rcvbuf`
- `route-delay`
- `route-method`
- `route-pull`
- `tls-client`
- `sndbuf`

It also moves the `route` option from the `server.jinja` into the `common_opts.jinja` as this is a valid option in OpenVPN for both server and client.