### PR TITLE
Create DH parameters on OpenVPN servers only

### DIFF
--- a/openvpn/files/common_opts.jinja
+++ b/openvpn/files/common_opts.jinja
@@ -131,7 +131,7 @@ key {{ config.key }}
 
 {%- if config.dh is defined %}
 dh {{ config.dh }}
-{%- else %}
+{%- elif config.server is defined  %}
 dh dh1024.pem
 {%- endif %}
 

--- a/openvpn/init.sls
+++ b/openvpn/init.sls
@@ -26,11 +26,13 @@ openvpn_external_repo:
 {%- endif %}
 
 # Generate diffie hellman files
-{%- for dh in map.dh_files %}
+{% if salt['pillar.get']('openvpn:server', False) %}
+  {%- for dh in map.dh_files %}
 openvpn_create_dh_{{ dh }}:
   cmd.run:
     - name: openssl dhparam -out {{ map.conf_dir }}/dh{{ dh }}.pem {{ dh }}
     - creates: {{ map.conf_dir }}/dh{{ dh }}.pem
     - require:
       - pkg: openvpn_pkgs
-{%- endfor %}
+  {%- endfor %}
+{% endif %}


### PR DESCRIPTION
Prevent generating Diffie-Hellman parameters unless an openvpn:server block is defined in pillar.

From the man page:
```
--dh file File containing Diffie Hellman parameters in .pem format (required for --tls-server only).
```