### PR TITLE
Tidy up file declarations in config.sls

### DIFF
--- a/openvpn/config.sls
+++ b/openvpn/config.sls
@@ -3,7 +3,7 @@
 include:
   - openvpn
 
-{% macro _set_file(config, map, type, name, file_type, private=False, contents=False) %}
+{% macro _print_file_block(config, map, type, name, file_type, private=False, contents=False) %}
 {% if config[file_type] is defined %}
 openvpn_{{ type }}_{{ name }}_{{ file_type }}_file:
   file.managed:
@@ -127,7 +127,7 @@ openvpn_config_{{ type }}_{{ name }}_tls_crypt_file:
     - watch_in:
       - service: {{ service_id }}
 {% elif config.ta_content is defined and config.tls_auth is defined %}
-{{ _set_file(config, map, type, name, 'tls_auth', private=True, contents='ta_content') }}
+{{ _print_file_block(config, map, type, name, 'tls_auth', private=True, contents='ta_content') }}
 {% endif %}
 
 {% if config.secret is defined and config.secret_content is defined %}
@@ -175,8 +175,8 @@ openvpn_{{ type }}_{{ name }}_status_file:
 {%- endif %}
 {% endif %}
 
-{{ _set_file(config, map, type, name, 'log') }}
-{{ _set_file(config, map, type, name, 'log_append') }}
+{{ _print_file_block(config, map, type, name, 'log') }}
+{{ _print_file_block(config, map, type, name, 'log_append') }}
 
 {% if config.client_config_dir is defined %}
 # Ensure client config dir exists

--- a/openvpn/config.sls
+++ b/openvpn/config.sls
@@ -3,6 +3,14 @@
 include:
   - openvpn
 
+{% macro _get_priv_opts(config, map) %}
+{% if not grains['os_family'] == 'Windows' %}
+    - mode: 600
+    - user: {% if config.user is defined %}{{ config.user }}{% else %}{{ map.user }}{% endif %}
+    - group: {% if config.group is defined %}{{ config.group }}{% else %}{{ map.group }}{% endif %}
+{% endif %}
+{% endmacro %}
+
 {% for type, names in salt['pillar.get']('openvpn', {}).iteritems() %}
 {% if type in ['client', 'server', 'peer'] %}
 {% for name, config in names.iteritems() %}
@@ -108,9 +116,7 @@ openvpn_config_{{ type }}_{{ name }}_tls_auth_file:
     - name: {{ config.tls_auth.split()[0] }}
     - contents_pillar: openvpn:{{ type }}:{{ name }}:ta_content
     - makedirs: True
-    - mode: 600
-    - user: {% if config.user is defined %}{{ config.user }}{% else %}{{ map.user }}{% endif %}
-    - group: {% if config.group is defined %}{{ config.group }}{% else %}{{ map.group }}{% endif %}
+    {{ _get_priv_opts(config, map) }}
     - watch_in:
       - service: {{ service_id }}
 {% endif %}

--- a/openvpn/config.sls
+++ b/openvpn/config.sls
@@ -3,9 +3,11 @@
 include:
   - openvpn
 
-{% macro _get_priv_opts(config, map) %}
+{% macro _get_file_opts(config, map, private=False ) %}
 {% if not grains['os_family'] == 'Windows' %}
+  {% if private %}
     - mode: 600
+  {% endif %}
     - user: {% if config.user is defined %}{{ config.user }}{% else %}{{ map.user }}{% endif %}
     - group: {% if config.group is defined %}{{ config.group }}{% else %}{{ map.group }}{% endif %}
 {% endif %}
@@ -116,7 +118,7 @@ openvpn_config_{{ type }}_{{ name }}_tls_auth_file:
     - name: {{ config.tls_auth.split()[0] }}
     - contents_pillar: openvpn:{{ type }}:{{ name }}:ta_content
     - makedirs: True
-    {{ _get_priv_opts(config, map) }}
+    {{ _get_file_opts(config, map, private=True) }}
     - watch_in:
       - service: {{ service_id }}
 {% endif %}
@@ -172,8 +174,7 @@ openvpn_{{ type }}_{{ name }}_log_file:
   file.managed:
     - name: {{ config.log }}
     - makedirs: True
-    - user: {% if config.user is defined %}{{ config.user }}{% else %}{{ map.user }}{% endif %}
-    - group: {% if config.group is defined %}{{ config.group }}{% else %}{{ map.group }}{% endif %}
+    {{ _get_file_opts(config, map) }}
     - watch_in:
 {%- if map.multi_services %}
       - service: openvpn_{{name}}_service
@@ -188,8 +189,7 @@ openvpn_{{ type }}_{{ name }}_log_file_append:
   file.managed:
     - name: {{ config.log_append }}
     - makedirs: True
-    - user: {% if config.user is defined %}{{ config.user }}{% else %}{{ map.user }}{% endif %}
-    - group: {% if config.group is defined %}{{ config.group }}{% else %}{{ map.group }}{% endif %}
+    {{ _get_file_opts(config, map) }}
 {% endif %}
 
 {% if config.client_config_dir is defined %}


### PR DESCRIPTION
```mode``` operation of ```file.managed``` is not supported on Windows, and rather than being ignored, it causes states to fail.
Therefore ```mode``` cannot be used when running the formula on Windows.

Rather than making many small changes to file states, I've pulled out a macro to encapsulate the differences required for Windows, and to cut down on repetition.

I haven't finished yet, but before going any further I'd like to canvas some opinions on whether this is the way to go? Thoughts?