### PR TITLE
Permissions macro

### DIFF
--- a/openvpn/config.sls
+++ b/openvpn/config.sls
@@ -146,7 +146,7 @@ openvpn_{{ type }}_{{ name }}_status_file:
   file.managed:
     - name: {{ config.status }}
     - makedirs: True
-    {{ _permissions(600, 'root', 0) }}  # different names on FreeBSD and Debian/Ubuntu
+    {{ _permissions(600, 'root', 0) }}  # different group names on FreeBSD and Debian/Ubuntu
     - watch_in:
 {%- if map.multi_services %}
       - service: openvpn_{{name}}_service

--- a/pillar.example
+++ b/pillar.example
@@ -164,7 +164,13 @@ openvpn:
       http_proxy_retry:
       http_proxy: 'proxy-server proxy-port'
       mute_replay_warnings:
+{% if grains['os_family'] == 'Windows' %}
+      dev_node: ovpn-myclient2
+      # Take care with the quoting for Windows paths with spaces
+      ca: '"C:\\Program Files\\OpenVPN\\config\\mycacert.pem"'
+{% else %}
       ca: /path/to/mycacert.pem
+{% endif %}
       ca_content: |
         -----BEGIN CERTIFICATE-----
         ...


### PR DESCRIPTION
```mode``` operation of ```file.managed``` is not supported on Windows, and rather than being ignored, it causes states to fail. Therefore ```mode``` cannot be used when running the formula on Windows. Similarly, ```user/group``` are not so useful on Windows.

This PR introduces a macro ```_permissions``` that excludes these parameters when used on Windows.

Follows on from #69.