### PR TITLE
Manage TAP-Windows device adapters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,11 @@ Configures OpenVPN client and server. Multiple clients and servers are possible.
 
 Configures OpenVPN GUI (Windows only). Sets global registry settings as described `here <https://github.com/OpenVPN/openvpn-gui/#registry-values-affecting-the-openvpn-gui-operation>`_.
 
+``openvpn.adapters``
+--------
+
+Manages TAP-Windows device adapters (Windows only). Ensures that any devices specified with ``dev_node`` in pillar exist.
+
 ``openvpn.ifconfig_pool_persist``
 ---------------------------------
 

--- a/openvpn/adapters.sls
+++ b/openvpn/adapters.sls
@@ -1,13 +1,19 @@
 include:
   - openvpn
 
-{% for adapter in salt['pillar.get']('openvpn:adapters:tap', []) %}
-openvpn_tap_adapter_{{ adapter }}:
+{% for type, names in salt['pillar.get']('openvpn', {}).items() %}
+{%   if type in ['client', 'server', 'peer'] %}
+{%     for name, config in names.items() %}
+{%       if config.dev_node is defined %}
+openvpn_tap_adapter_{{ config.dev_node }}:
   cmd.script:
     - source: salt://openvpn/files/tap-adapter.ps1
-    - args: -New {{ adapter }}
+    - args: -New {{ config.dev_node }}
     - shell: powershell
     - stateful: True
     - require:
       - pkg: openvpn_pkgs
+{%       endif %}
+{%     endfor %}
+{%   endif %}
 {% endfor %}

--- a/openvpn/adapters.sls
+++ b/openvpn/adapters.sls
@@ -1,3 +1,4 @@
+{% if salt['grains.get']('os_family') == 'Windows' %}
 include:
   - openvpn
 
@@ -17,3 +18,5 @@ openvpn_tap_adapter_{{ config.dev_node }}:
 {%     endfor %}
 {%   endif %}
 {% endfor %}
+
+{% endif %}

--- a/openvpn/adapters.sls
+++ b/openvpn/adapters.sls
@@ -7,6 +7,7 @@ openvpn_tap_adapter_{{ adapter }}:
     - source: salt://openvpn/files/tap-adapter.ps1
     - args: -New {{ adapter }}
     - shell: powershell
+    - stateful: True
     - require:
       - pkg: openvpn_pkgs
 {% endfor %}

--- a/openvpn/adapters.sls
+++ b/openvpn/adapters.sls
@@ -1,0 +1,12 @@
+include:
+  - openvpn
+
+{% for adapter in salt['pillar.get']('openvpn:adapters:tap', []) %}
+openvpn_tap_adapter_{{ adapter }}:
+  cmd.script:
+    - source: salt://openvpn/files/tap-adapter.ps1
+    - args: -New {{ adapter }}
+    - shell: powershell
+    - require:
+      - pkg: openvpn_pkgs
+{% endfor %}

--- a/openvpn/files/tap-adapter.ps1
+++ b/openvpn/files/tap-adapter.ps1
@@ -1,0 +1,25 @@
+﻿param([Parameter(Mandatory, ParameterSetName = 'new')][string]$New,
+        [Parameter(Mandatory, ParameterSetName = 'remove')][string]$Remove)
+        
+
+$tapDesc = 'TAP-Windows Adapter V9*'
+$tapDir = $env:ProgramFiles + "\TAP-Windows"
+$tapInstallCmd = "$tapDir\bin\tapinstall.exe"
+$tapInstallArgs = "install", "`"$tapDir\driver\OemVista.inf`"", "tap0901"     # Backtick quotes https://stackoverflow.com/q/17550663
+
+if ($PSCmdlet.ParameterSetName -eq 'new') {
+    if (Get-NetAdapter -InterfaceDescription $tapDesc | Where-Object Name -eq ovpn-$New) { 
+        exit
+    }
+    if (-Not (Get-NetAdapter -InterfaceDescription $tapDesc | Where-Object Name -Like Eth*)) {
+        $p = Start-Process $tapInstallCmd -ArgumentList $tapInstallArgs -NoNewWindow -Wait -PassThru
+    }
+    Get-NetAdapter -InterfaceDescription $tapDesc | Where-Object Name -Like Eth* `
+        | Select-Object -First 1 | Rename-NetAdapter -NewName ovpn-$New
+}
+
+if ($PSCmdlet.ParameterSetName -eq 'remove') {
+    # No practical way to remove individual TAP adapter, so rename randomly to get it "out of the way"
+    Get-NetAdapter -Name ovpn-$Remove | Rename-NetAdapter -NewName "tmp$(Get-Random -Min 10 -Max 999)"   
+}
+

--- a/openvpn/files/tap-adapter.ps1
+++ b/openvpn/files/tap-adapter.ps1
@@ -9,6 +9,7 @@ $tapInstallArgs = "install", "`"$tapDir\driver\OemVista.inf`"", "tap0901"     # 
 
 if ($PSCmdlet.ParameterSetName -eq 'new') {
     if (Get-NetAdapter -InterfaceDescription $tapDesc | Where-Object Name -eq ovpn-$New) { 
+        Write-Host "changed=no comment=`'TAP-Windows adapter $New exists`'"
         exit
     }
     if (-Not (Get-NetAdapter -InterfaceDescription $tapDesc | Where-Object Name -Like Eth*)) {
@@ -16,10 +17,12 @@ if ($PSCmdlet.ParameterSetName -eq 'new') {
     }
     Get-NetAdapter -InterfaceDescription $tapDesc | Where-Object Name -Like Eth* `
         | Select-Object -First 1 | Rename-NetAdapter -NewName ovpn-$New
+    Write-Host "changed=yes comment=`'TAP-Windows adapter $New created`'"
 }
 
 if ($PSCmdlet.ParameterSetName -eq 'remove') {
     # No practical way to remove individual TAP adapter, so rename randomly to get it "out of the way"
     Get-NetAdapter -Name ovpn-$Remove | Rename-NetAdapter -NewName "tmp$(Get-Random -Min 10 -Max 999)"   
+    Write-Host "changed=yes comment=`'TAP-Windows adapter $Remove removed`'"
 }
 

--- a/openvpn/files/tap-adapter.ps1
+++ b/openvpn/files/tap-adapter.ps1
@@ -8,7 +8,7 @@ $tapInstallCmd = "$tapDir\bin\tapinstall.exe"
 $tapInstallArgs = "install", "`"$tapDir\driver\OemVista.inf`"", "tap0901"     # Backtick quotes https://stackoverflow.com/q/17550663
 
 if ($PSCmdlet.ParameterSetName -eq 'new') {
-    if (Get-NetAdapter -InterfaceDescription $tapDesc | Where-Object Name -eq ovpn-$New) { 
+    if (Get-NetAdapter -InterfaceDescription $tapDesc | Where-Object Name -eq $New) {
         Write-Host "changed=no comment=`'TAP-Windows adapter $New exists`'"
         exit
     }
@@ -16,13 +16,13 @@ if ($PSCmdlet.ParameterSetName -eq 'new') {
         $p = Start-Process $tapInstallCmd -ArgumentList $tapInstallArgs -NoNewWindow -Wait -PassThru
     }
     Get-NetAdapter -InterfaceDescription $tapDesc | Where-Object Name -Like Eth* `
-        | Select-Object -First 1 | Rename-NetAdapter -NewName ovpn-$New
+        | Select-Object -First 1 | Rename-NetAdapter -NewName $New
     Write-Host "changed=yes comment=`'TAP-Windows adapter $New created`'"
 }
 
 if ($PSCmdlet.ParameterSetName -eq 'remove') {
     # No practical way to remove individual TAP adapter, so rename randomly to get it "out of the way"
-    Get-NetAdapter -Name ovpn-$Remove | Rename-NetAdapter -NewName "tmp$(Get-Random -Min 10 -Max 999)"   
+    Get-NetAdapter -Name $Remove | Rename-NetAdapter -NewName "tmp$(Get-Random -Min 10 -Max 999)"
     Write-Host "changed=yes comment=`'TAP-Windows adapter $Remove removed`'"
 }
 


### PR DESCRIPTION
On Windows, TAP-Windows devices need to be managed manually.

This PR ensures a net adapter exists with the name specified using ```dev_node:``` in pillar.