### PR TITLE
Add configuration for Openvpn-GUI (Windows only)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,11 @@ Installs OpenVPN.
 
 Configures OpenVPN client and server. Multiple clients and servers are possible.
 
+``openvpn.gui``
+--------
+
+Configures OpenVPN GUI (Windows only). Sets global registry settings as described `here <https://github.com/OpenVPN/openvpn-gui/#registry-values-affecting-the-openvpn-gui-operation>`_.
+
 ``openvpn.ifconfig_pool_persist``
 ---------------------------------
 

--- a/openvpn/gui.sls
+++ b/openvpn/gui.sls
@@ -1,0 +1,12 @@
+{% set reg_values = {'disable_save_passwords': 'something'} %}
+
+{% for name, data in salt['pillar.get']('openvpn:gui', {}).items() %}
+{%   if name in reg_values.keys() %}
+openvpn_gui_reg_{{ name }}:
+  reg.present:
+    - name: HKEY_LOCAL_MACHINE\SOFTWARE\OpenVPN
+    - vname: {{ name }}
+    - vdata: {{ data }}
+    - vtype: REG_DWORD
+{%   endif %}
+{% endfor %}

--- a/openvpn/gui.sls
+++ b/openvpn/gui.sls
@@ -1,4 +1,9 @@
-{% set reg_values = {'disable_save_passwords': 'something'} %}
+# See https://github.com/OpenVPN/openvpn-gui
+{% set reg_values = { 'config_dir': 'REG_SZ',
+                      'exe_path': 'REG_SZ',
+                      'priority': 'REG_SZ',
+                      'ovpn_admin_group': 'REG_SZ',
+                      'disable_save_passwords': 'REG_DWORD'} %}
 
 {% for name, data in salt['pillar.get']('openvpn:gui', {}).items() %}
 {%   if name in reg_values.keys() %}
@@ -7,6 +12,6 @@ openvpn_gui_reg_{{ name }}:
     - name: HKEY_LOCAL_MACHINE\SOFTWARE\OpenVPN
     - vname: {{ name }}
     - vdata: {{ data }}
-    - vtype: REG_DWORD
+    - vtype: {{ reg_values[name] }}
 {%   endif %}
 {% endfor %}

--- a/openvpn/gui.sls
+++ b/openvpn/gui.sls
@@ -1,3 +1,5 @@
+{% if salt['grains.get']('os_family') == 'Windows' %}
+
 # See https://github.com/OpenVPN/openvpn-gui
 {% set reg_values = { 'config_dir': 'REG_SZ',
                       'exe_path': 'REG_SZ',
@@ -15,3 +17,5 @@ openvpn_gui_reg_{{ name }}:
     - vtype: {{ reg_values[name] }}
 {%   endif %}
 {% endfor %}
+
+{% endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -234,3 +234,7 @@ openvpn:
     ipp.txt:
       somehostname: 192.168.51.2
       secondhost: 192.168.51.3
+
+  # See GUI config options https://github.com/OpenVPN/openvpn-gui
+  gui:
+    disable_save_passwords: 1


### PR DESCRIPTION
Allows setting global config options for the OpenVPN GUI on Windows.