### PR TITLE
Fix encoding when passing config

### DIFF
--- a/openvpn/config.sls
+++ b/openvpn/config.sls
@@ -33,7 +33,8 @@ openvpn_config_{{ type }}_{{ name }}:
     - template: jinja
     - context:
         name: {{ name }}
-        config: {{ config }}
+        config:
+          {{ config | json_encode_dict }}
         user: {{ map.user }}
         group: {{ map.group }}
     - watch_in:


### PR DESCRIPTION
When using `verify_x509_name: "'C=AT, CN=my.fqdn, L=-, ST=-'"` via `salt-ssh` the resulting config file contained

```
verify-x509-name u"'C=AT
```

This is fixed by encoding the config data structure  in `config.sls` as JSON.

```
% salt --versions-report
Salt Version:
           Salt: 2018.3.1

Dependency Versions:
           cffi: 1.11.5
       cherrypy: Not Installed
       dateutil: Not Installed
      docker-py: Not Installed
          gitdb: Not Installed
      gitpython: Not Installed
          ioflo: Not Installed
         Jinja2: 2.10
        libgit2: Not Installed
        libnacl: Not Installed
       M2Crypto: 0.30.1
           Mako: Not Installed
   msgpack-pure: Not Installed
 msgpack-python: 0.5.6
   mysql-python: 1.2.5
      pycparser: 2.18
       pycrypto: 2.6.1
   pycryptodome: Not Installed
         pygit2: Not Installed
         Python: 2.7.15 (default, May 27 2018, 00:32:32)
   python-gnupg: Not Installed
         PyYAML: 3.13
          PyZMQ: 17.0.0
           RAET: Not Installed
          smmap: Not Installed
        timelib: Not Installed
        Tornado: 4.5.3
            ZMQ: 4.2.3

System Versions:
           dist:
         locale: UTF-8
        machine: amd64
        release: 11.2-RELEASE
         system: FreeBSD
        version: Not Installed
```