### PR TITLE
Turn off compression by default (VORACLE)

### DIFF
--- a/openvpn/files/common_opts.jinja
+++ b/openvpn/files/common_opts.jinja
@@ -96,7 +96,7 @@ persist-tun
 
 ; Data transfer
 {%- if not (config.comp_lzo is defined and config.comp_lzo == False) %}
-comp-lzo
+comp-lzo no
 {%- endif %}
 
 


### PR DESCRIPTION
https://www.bleepingcomputer.com/news/security/voracle-attack-can-recover-http-data-from-vpn-connections/