### PR TITLE
Fix flaw in #87 so that comp-lzo can be switched on

### DIFF
--- a/openvpn/files/common_opts.jinja
+++ b/openvpn/files/common_opts.jinja
@@ -95,8 +95,10 @@ persist-tun
 
 
 ; Data transfer
-{%- if not (config.comp_lzo is defined and config.comp_lzo == False) %}
+{%- if config.comp_lzo is defined and config.comp_lzo == False %}
 comp-lzo no
+{%- elif config.comp_lzo is defined %}
+comp-lzo {{ config.comp_lzo }}
 {%- endif %}
 
 


### PR DESCRIPTION
After #87 there's no way for someone to turn on comp-lzo.

This PR fixes that, keeping back compat in case someone is using comp_lzo: False, and allowing someone to specify the valid options yes, no or adaptive.
If comp_lzo is unconfigured in pillar, then leave it out of the configuration, retaining the default of no compression.