### PR TITLE
NetworkManager support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,11 @@ Manages TAP-Windows device adapters (Windows only). Ensures that any devices spe
 
 Installs and configures an ifconfig_pool_persist file. Used to assign host IPs.
 
+``openvpn.network_manager_networks``
+------------------------------------
+
+Don't setup a OpenVPN client service, but add ready-to-use NetworkManager configurations.
+
 Example
 =======
 

--- a/openvpn/defaults.yaml
+++ b/openvpn/defaults.yaml
@@ -11,3 +11,6 @@ openvpn:
   pkgs: ['openvpn']
   service: openvpn
   user: nobody
+  network_manager_pkgs:
+    - network-manager-openvpn
+    - network-manager-openvpn-gnome

--- a/openvpn/dhparams.sls
+++ b/openvpn/dhparams.sls
@@ -1,0 +1,13 @@
+{%- from "openvpn/map.jinja" import map with context %}
+
+# Generate diffie hellman files
+{% if salt['pillar.get']('openvpn:server', False) %}
+  {%- for dh in map.dh_files %}
+openvpn_create_dh_{{ dh }}:
+  cmd.run:
+    - name: openssl dhparam {% if map.dsaparam %}-dsaparam {% endif %}-out {{ map.conf_dir }}/dh{{ dh }}.pem {{ dh }}
+    - creates: {{ map.conf_dir }}/dh{{ dh }}.pem
+    - require:
+      - pkg: openvpn_pkgs
+  {%- endfor %}
+{% endif %}

--- a/openvpn/files/common_opts.jinja
+++ b/openvpn/files/common_opts.jinja
@@ -312,3 +312,7 @@ sndbuf {{ config.sndbuf }}
 {%- if config.rcvbuf is defined %}
 rcvbuf {{ config.rcvbuf }}
 {% endif %}
+
+{%  if config.get('float', False) -%}
+float
+{%- endif %}

--- a/openvpn/files/common_opts.jinja
+++ b/openvpn/files/common_opts.jinja
@@ -1,4 +1,9 @@
 {% from "openvpn/map.jinja" import multipart_param with context %}
+
+{%- if config.daemon is defined and config.daemon == True %}
+daemon
+{%- endif -%}
+
 ; Networking
 {%- if config.dev_node is defined %}
 dev-node {{ config.dev_node }}
@@ -16,6 +21,12 @@ tun-ipv6
 proto {{ config.proto }}
 {%- else %}
 proto udp
+{%- endif %}
+
+{%- if config.port is defined %}
+port {{ config.port }}
+{%- else %}
+port 1194
 {%- endif %}
 
 {%- if config.ping is defined %}

--- a/openvpn/files/server.jinja
+++ b/openvpn/files/server.jinja
@@ -15,18 +15,8 @@ tls-server
 local {{ config.local }}
 {%- endif %}
 
-{%- if config.port is defined %}
-port {{ config.port }}
-{%- else %}
-port 1194
-{%- endif %}
-
 {%- if config.port_share is defined %}
 port-share {{ config.port_share }}
-{%- endif %}
-
-{%- if config.daemon is defined and config.daemon == True %}
-daemon
 {%- endif %}
 
 {%- if config.topology is defined %}

--- a/openvpn/init.sls
+++ b/openvpn/init.sls
@@ -1,46 +1,7 @@
 # This is the main state file for configuring openvpn.
-{%- from "openvpn/map.jinja" import map with context %}
 
 include:
+  - openvpn.repo
+  - openvpn.install
+  - openvpn.dhparams
   - openvpn.service
-
-# Install openvpn packages
-openvpn_pkgs:
-  pkg.installed:
-    - pkgs:
-      {%- for pkg in map.pkgs %}
-      - {{ pkg }}
-      {%- endfor %}
-{% if salt['grains.get']('os_family') == 'Windows' %}
-    - require:
-      - win_pki: openvpn_publisher_cert
-
-openvpn_publisher_cert:
-  win_pki.import_cert:
-    - name: salt://openvpn/files/openvpn-1.cer
-    - store: TrustedPublisher
-{% endif %}
-
-{%- if map.external_repo_enabled == True and grains['os_family'] == "Debian" and grains['oscodename'] in map.external_repo_supported %}
-# Install openvpn external repository
-# https://community.openvpn.net/openvpn/wiki/OpenvpnSoftwareRepos
-openvpn_external_repo:
-  pkgrepo.managed:
-    - name: deb http://build.openvpn.net/debian/openvpn/{{ map.external_repo_version }} {{ grains['oscodename'] }} main
-    - file: /etc/apt/sources.list.d/openvpn-aptrepo.list
-    - key_url: https://swupdate.openvpn.net/repos/repo-public.gpg
-    - require_in:
-      - pkg: openvpn_pkgs
-{%- endif %}
-
-# Generate diffie hellman files
-{% if salt['pillar.get']('openvpn:server', False) %}
-  {%- for dh in map.dh_files %}
-openvpn_create_dh_{{ dh }}:
-  cmd.run:
-    - name: openssl dhparam {% if map.dsaparam %}-dsaparam {% endif %}-out {{ map.conf_dir }}/dh{{ dh }}.pem {{ dh }}
-    - creates: {{ map.conf_dir }}/dh{{ dh }}.pem
-    - require:
-      - pkg: openvpn_pkgs
-  {%- endfor %}
-{% endif %}

--- a/openvpn/install.sls
+++ b/openvpn/install.sls
@@ -1,0 +1,18 @@
+{%- from "openvpn/map.jinja" import map with context %}
+
+# Install openvpn packages
+openvpn_pkgs:
+  pkg.installed:
+    - pkgs:
+      {%- for pkg in map.pkgs %}
+      - {{ pkg }}
+      {%- endfor %}
+{% if salt['grains.get']('os_family') == 'Windows' %}
+    - require:
+      - win_pki: openvpn_publisher_cert
+
+openvpn_publisher_cert:
+  win_pki.import_cert:
+    - name: salt://openvpn/files/openvpn-1.cer
+    - store: TrustedPublisher
+{% endif %}

--- a/openvpn/install.sls
+++ b/openvpn/install.sls
@@ -2,7 +2,11 @@
 
 # Install openvpn packages
 openvpn_pkgs:
+{%- if salt['pillar.get']('openvpn:use_latest', False) %}
+  pkg.latest:
+{% else %}
   pkg.installed:
+{% endif %}
     - pkgs:
       {%- for pkg in map.pkgs %}
       - {{ pkg }}

--- a/openvpn/network_manager_networks/files/connection.jinja
+++ b/openvpn/network_manager_networks/files/connection.jinja
@@ -1,0 +1,95 @@
+{%- from "openvpn/map.jinja" import multipart_param with context -%}
+{%- set config = salt['pillar.get']('openvpn:network_manager:networks:'+network_name, {}) -%}
+{%- macro pairs(data) -%}
+{%-   for key, value in data|dictsort -%}
+{{ key|replace('_', '-') }}={{ value }}
+{%    endfor -%}
+{%- endmacro -%}
+
+[connection]
+{%- if not 'id' in config.get('connection', {}) -%}
+{%-   if '_name' in config %}
+id={{ config.get('_name') }}
+{%-   else %}
+id={{ network_name }}
+{%-   endif %}
+{%- endif %}
+uuid={{ salt['cmd.run']("python2 -c \"import uuid; print uuid.uuid5(uuid.NAMESPACE_DNS, '{}{}')\"".format(network_name, grains['id'])) }}
+{{ pairs(config.get('connection', {})) }}
+
+{%- for segment, data in config|dictsort -%}
+{%-   if segment|list|first == '_' %}{% continue %}{% endif -%}
+{%-   if segment == 'connection' %}{% continue %}{% endif %}
+[{{ segment }}]
+{%-   if segment == 'vpn' %}
+{%-     if config[segment].get('service_type', 'org.freedesktop.NetworkManager.openvpn') == 'org.freedesktop.NetworkManager.openvpn' %}
+{%-       set instance_name = config.get('_vpn_instance', network_name) %}
+{%-       set vpn_data = salt['pillar.get']('openvpn:client:'+instance_name, {}) %}
+connection-type=tls
+
+{%-       for key in ['ca', 'key', 'cert', 'remote_cert_tls'] -%}
+{%-         if key in vpn_data %}
+{{ key|replace('_', '-') }}={{ vpn_data[key] }}
+{%-         endif -%}
+{%-       endfor %}
+
+{%-       if 'ciphers' in vpn_data %}
+cipher={{ vpn_data['ciphers']|first }}
+{%-       endif %}
+
+{%-       if 'auths' in vpn_data %}
+auth={{ vpn_data['auths']|first }}
+{%-       endif %}
+
+{%-       set remote_list = vpn_data.get('remote', False) %}
+{%-       set remote = config[segment].get('remote', False) %}
+{%-       if remote %}
+{%-         set port = config[segment].pop('port', 1194) %}
+{%-       elif remote_list is iterable %}
+{%-         set remote_pair = remote_list[0].split(' ') %}
+{%-         set remote = remote_pair|first %}
+{%-         set port = config[segment].pop('port', False) %}
+{%-         if port != False and remote_pair|length > 1 %}
+{%-           set port = remote_pair|last %}
+{%-         else %}
+{%-           set port = 1194 %}
+{%-         endif %}
+{%-       endif %}
+{%-       if remote and port %}
+remote={{ remote }}
+port={{ port }}
+{%-       endif %}
+
+{%-       if 'tls_auth' in vpn_data %}
+ta-dir={{ multipart_param(vpn_data.tls_auth, 1) }}
+ta={{ multipart_param(vpn_data.tls_auth, 0) }}
+{%-       endif -%}
+
+{%-       if 'tun_mtu' in vpn_data %}
+tunnel-mtu={{ vpn_data['tun_mtu'] }}
+{%-       endif -%}
+
+{%-       if 'comp_lzo' in vpn_data %}
+comp-lzo={{ vpn_data['comp_lzo'] }}
+{%-       endif -%}
+
+{%-       if 'key_passphrase' in vpn_data and (grains['saltversioninfo'][0] > 2017 ) %}
+{# 2016.11: x509.private_key_managed has no parameter 'passphrase' #}
+cert-pass-flags=1
+{%-       endif -%}
+
+{%-       if vpn_data.get('proto') == 'tcp' %}
+proto-tcp=yes
+{%-       endif -%}
+
+{#- NOT WORKING IN Ubuntu 16.04 #}
+{%-       if salt['grains.get']('osfinger') != 'Ubuntu-16.04' %}
+{%-         if 'verify_x509_name' in vpn_data %}
+tls-remote=/{{ vpn_data['verify_x509_name']|replace(', ', '/')|replace("'", "") }}
+{%-         endif -%}
+{%-       endif -%}
+
+{%-     endif -%}
+{%-   endif %}
+{{ pairs(config[segment]) }}
+{%- endfor -%}

--- a/openvpn/network_manager_networks/init.sls
+++ b/openvpn/network_manager_networks/init.sls
@@ -1,0 +1,33 @@
+{% from "openvpn/map.jinja" import map with context %}
+
+include:
+  - openvpn.repo
+
+{%- for pkg_name in map.network_manager_pkgs %}
+{{ pkg_name }}:
+  pkg.installed: []
+{%- endfor %}
+
+{%- set networks = salt['pillar.get']('openvpn:network_manager:networks', {}) %}
+
+{%- for name, data in networks.items() %}
+"/etc/NetworkManager/system-connections/{{ name }}":
+{%-   if data.get('remove', False) %}
+  file.absent: []
+{%-   else %}
+  file.managed:
+    - template: jinja
+    - source: salt://openvpn/network_manager_networks/files/connection.jinja
+    - defaults:
+      network_name: "{{ name }}"
+    - mode: 600
+    - onchanges_in:
+      - cmd: network_manager_connection_reload
+{%-   endif %}
+{%- endfor %}
+
+{%- if networks.keys()|length > 0 %}
+network_manager_connection_reload:
+  cmd.run:
+    - name: '/usr/bin/nmcli connection reload'
+{%- endif %}

--- a/openvpn/osmap.yaml
+++ b/openvpn/osmap.yaml
@@ -1,4 +1,10 @@
 Debian:
-  external_repo_supported: ['wheezy', 'jessie', 'stretch']
+  external_repo_supported:
+    - wheezy
+    - jessie
+    - stretch
 Ubuntu:
-  external_repo_supported: ['precise', 'trusty', 'xenial']
+  external_repo_supported:
+    - precise
+    - trusty
+    - xenial

--- a/openvpn/repo.sls
+++ b/openvpn/repo.sls
@@ -1,0 +1,13 @@
+{%- from "openvpn/map.jinja" import map with context %}
+
+{%- if map.external_repo_enabled == True and grains['os_family'] == "Debian" and grains['oscodename'] in map.external_repo_supported %}
+# Install openvpn external repository
+# https://community.openvpn.net/openvpn/wiki/OpenvpnSoftwareRepos
+openvpn_external_repo:
+  pkgrepo.managed:
+    - name: deb http://build.openvpn.net/debian/openvpn/{{ map.external_repo_version }} {{ grains['oscodename'] }} main
+    - file: /etc/apt/sources.list.d/openvpn-aptrepo.list
+    - key_url: https://swupdate.openvpn.net/repos/repo-public.gpg
+    - require_in:
+      - pkg: openvpn_pkgs
+{%- endif %}

--- a/openvpn/repo.sls
+++ b/openvpn/repo.sls
@@ -1,5 +1,8 @@
 {%- from "openvpn/map.jinja" import map with context %}
 
+include:
+  - openvpn.install
+
 {%- if map.external_repo_enabled == True and grains['os_family'] == "Debian" and grains['oscodename'] in map.external_repo_supported %}
 # Install openvpn external repository
 # https://community.openvpn.net/openvpn/wiki/OpenvpnSoftwareRepos

--- a/openvpn/service.sls
+++ b/openvpn/service.sls
@@ -30,7 +30,7 @@ openvpn_{{ name }}_service:
     - enable: True
     - require:
       - pkg: openvpn_pkgs
-      - sls: openvpn
+      - sls: openvpn.install
 {% if grains['os_family'] == 'FreeBSD' %}
     - watch:
       - file: /usr/local/etc/rc.d/openvpn_{{ name }}
@@ -47,5 +47,5 @@ openvpn_service:
     - enable: True
     - require:
       - pkg: openvpn_pkgs
-      - sls: openvpn
+      - sls: openvpn.install
 {% endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -269,6 +269,9 @@ openvpn:
   gui:
     disable_save_passwords: 1
 
+  ##
+  # Use latest OpenVPN packages (default: false)
+  use_latest: False
 
   # Managing clients which use NetworkManager
   # (Intentionally does not handle certificate/key distribution!)

--- a/pillar.example
+++ b/pillar.example
@@ -268,3 +268,37 @@ openvpn:
   # See GUI config options https://github.com/OpenVPN/openvpn-gui
   gui:
     disable_save_passwords: 1
+
+
+  # Managing clients which use NetworkManager
+  # (Intentionally does not handle certificate/key distribution!)
+  network_manager:
+    networks:
+      myserver_udp: &myserver_udp_net
+        _vpn_instance: myserver
+        _name: '(Salt) myserver UDP'
+        connection:
+          type: vpn
+          permissions: 'user:a:;'
+          autoconnect: 'false'
+        vpn: &vpn
+          # optional
+          service_type: org.freedesktop.NetworkManager.openvpn
+          # remote defaults to openvpn:client:${vpn_instance}:remote
+          remote: '1.2.3.4'
+          # optional
+          port: 1194
+        ipv4:
+          method: auto
+          never_default: 'true'
+        ipv6:
+          method: ignore
+
+      myserver_tcp: &myserver_tcp_net
+        <<: *myserver_udp_net
+        _vpn_instance: myserver_tcp
+        _name: '(Salt) myserver TCP'
+
+      # Remove config file from NetworkManager
+      myoldserver:
+        remove: true


### PR DESCRIPTION
- made list of supported OS distribution versions more maintainable
- split `init.sls` into re-usable sub-states
- implemented management of NetworkManager OpenVPN networks
- made options `daemon` and `port` usable by clients too

Tested on

- FreeBSD 11.2-RELEASE-p4
- Ubuntu 18.04.1 LTS
- Debian GNU/Linux 9.5 (stretch)
- Ubuntu 16.04.5 LTS