### PR TITLE
Add some missing options

### DIFF
--- a/openvpn/files/common_opts.jinja
+++ b/openvpn/files/common_opts.jinja
@@ -49,6 +49,10 @@ ping-timer-rem
 keepalive {{ config.keepalive }}
 {%- endif %}
 
+{%- if config.persist_remote_ip is defined and config.persist_remote_ip == True %}
+persist-remote-ip
+{%- endif %}
+
 {%- if config.tun_mtu is defined %}
 tun-mtu {{ config.tun_mtu }}
 {%- endif %}

--- a/openvpn/files/server.jinja
+++ b/openvpn/files/server.jinja
@@ -99,6 +99,10 @@ plugin {{ plugin }}
 client-cert-not-required
 {%- endif %}
 
+{%- if config.verify_client_cert is defined %}
+verify-client-cert {{ config.verify_client_cert }}
+{%- endif %}
+
 {%- if config.management is defined %}
 management {{ config.management }}
 {%- endif %}


### PR DESCRIPTION
verify-client-cert is intended to eventually deprecate client-cert-not-required.
persist-remote-ip was missing.