### PR TITLE
Fixed file permissions; manage (non-default) user & group

### DIFF
--- a/openvpn/config.sls
+++ b/openvpn/config.sls
@@ -3,6 +3,7 @@
 
 include:
   - openvpn
+  - openvpn.general_config
 
 {% for type, names in salt['pillar.get']('openvpn', {}).items() %}
 {% if type in ['client', 'server', 'peer'] %}

--- a/openvpn/config.sls
+++ b/openvpn/config.sls
@@ -26,6 +26,7 @@ include:
 openvpn_config_{{ type }}_{{ name }}:
   file.managed:
     - name: {{ config_file }}
+    {{ _permissions(640, 'root') }}
     - source:
       - salt://openvpn/files/{{ type }}.jinja
       - salt://openvpn/files/common_opts.jinja  # make available to salt-ssh
@@ -44,6 +45,7 @@ openvpn_config_{{ type }}_{{ name }}:
 openvpn_config_{{ type }}_{{ name }}_ca_file:
   file.managed:
     - name: {{ config.ca }}
+    {{ _permissions(640, 'root') }}
     - contents_pillar: openvpn:{{ type }}:{{ name }}:ca_content
     - makedirs: True
     - watch_in:
@@ -55,6 +57,7 @@ openvpn_config_{{ type }}_{{ name }}_ca_file:
 openvpn_config_{{ type }}_{{ name }}_cert_file:
   file.managed:
     - name: {{ config.cert }}
+    {{ _permissions(640, 'root') }}
     - contents_pillar: openvpn:{{ type }}:{{ name }}:cert_content
     - makedirs: True
     - watch_in:
@@ -66,9 +69,9 @@ openvpn_config_{{ type }}_{{ name }}_cert_file:
 openvpn_config_{{ type }}_{{ name }}_key_file:
   file.managed:
     - name: {{ config.key }}
+    {{ _permissions(600, 'root') }}
     - contents_pillar: openvpn:{{ type }}:{{ name }}:key_content
     - makedirs: True
-    {{ _permissions(600) }}
     - watch_in:
       - service: {{ service_id }}
 {% endif %}
@@ -78,6 +81,7 @@ openvpn_config_{{ type }}_{{ name }}_key_file:
 openvpn_config_{{ type }}_{{ name }}_crl_verify_file:
   file.managed:
     - name: {{ config.crl_verify }}
+    {{ _permissions(640, 'root') }}
     - contents_pillar: openvpn:{{ type }}:{{ name }}:crl_verify_content
     - makedirs: True
     - watch_in:
@@ -89,9 +93,9 @@ openvpn_config_{{ type }}_{{ name }}_crl_verify_file:
 openvpn_config_{{ type }}_{{ name }}_passwd_file:
   file.managed:
     - name: {{ config.askpass }}
+    {{ _permissions(600, 'root') }}
     - contents_pillar: openvpn:{{ type }}:{{ name }}:askpass_content
     - makedirs: True
-    {{ _permissions(600) }}
     - watch_in:
       - service: {{ service_id }}
 {% endif %}
@@ -101,9 +105,9 @@ openvpn_config_{{ type }}_{{ name }}_passwd_file:
 openvpn_config_{{ type }}_{{ name }}_tls_crypt_file:
   file.managed:
     - name: {{ config.tls_crypt }}
+    {{ _permissions(600, 'root') }}
     - contents_pillar: openvpn:{{ type }}:{{ name }}:ta_content
     - makedirs: True
-    {{ _permissions(600) }}
     - watch_in:
       - service: {{ service_id }}
 {% elif config.ta_content is defined and config.tls_auth is defined %}
@@ -111,9 +115,9 @@ openvpn_config_{{ type }}_{{ name }}_tls_crypt_file:
 openvpn_config_{{ type }}_{{ name }}_tls_auth_file:
   file.managed:
     - name: {{ multipart_param(config.tls_auth, 0) }}
+    {{ _permissions(600, 'root') }}
     - contents_pillar: openvpn:{{ type }}:{{ name }}:ta_content
     - makedirs: True
-    {{ _permissions(600) }}
     - watch_in:
       - service: {{ service_id }}
 {% endif %}
@@ -123,9 +127,9 @@ openvpn_config_{{ type }}_{{ name }}_tls_auth_file:
 openvpn_config_{{ type }}_{{ name }}_secret_file:
   file.managed:
     - name: {{ multipart_param(config.secret, 0) }}
+    {{ _permissions(600, 'root') }}
     - contents_pillar: openvpn:{{ type }}:{{ name }}:secret_content
     - makedirs: True
-    {{ _permissions(600) }}
     - watch_in:
       - service: {{ service_id }}
 {% endif %}
@@ -135,9 +139,9 @@ openvpn_config_{{ type }}_{{ name }}_secret_file:
 openvpn_config_{{ type }}_{{ name }}_auth_user_pass_file:
   file.managed:
     - name: {{ config.auth_user_pass }}
+    {{ _permissions(600, 'root') }}
     - contents_pillar: openvpn:{{ type }}:{{ name }}:auth_user_pass_content
     - makedirs: True
-    {{ _permissions(600) }}
     - watch_in:
       - service: {{ service_id }}
 {% endif %}
@@ -163,7 +167,7 @@ openvpn_{{ type }}_{{ name }}_log_file:
   file.managed:
     - name: {{ config.log }}
     - makedirs: True
-    {{ _permissions() }}
+    {{ _permissions(640) }}
 {% endif %}
 
 {% if config.log_append is defined %}
@@ -172,7 +176,7 @@ openvpn_{{ type }}_{{ name }}_log_file_append:
   file.managed:
     - name: {{ config.log_append }}
     - makedirs: True
-    {{ _permissions() }}
+    {{ _permissions(640) }}
 {% endif %}
 
 {% if config.client_config_dir is defined %}
@@ -180,6 +184,7 @@ openvpn_{{ type }}_{{ name }}_log_file_append:
 openvpn_config_{{ type }}_{{ name }}_client_config_dir:
   file.directory:
     - name: {{ config_dir }}/{{ config.client_config_dir}}
+    {{ _permissions(750, 'root') }}
     - makedirs: True
     - watch_in:
 {%- if map.multi_services %}
@@ -193,6 +198,7 @@ openvpn_config_{{ type }}_{{ name }}_client_config_dir:
 openvpn_config_{{ type }}_{{ name }}_{{ client }}_client_config:
   file.managed:
     - name: {{ config_dir }}/{{ config.client_config_dir}}/{{ client }}
+    {{ _permissions(640, 'root') }}
     - contents_pillar: openvpn:{{ type }}:{{ name }}:client_config:{{ client }}
     - makedirs: True
     - watch_in:

--- a/openvpn/general_config.sls
+++ b/openvpn/general_config.sls
@@ -2,6 +2,32 @@
 
 {% from "openvpn/map.jinja" import map with context %}
 
+{%- if map.manage_group is sameas false or map.user in ['nobody', 'nogroup'] %}
+{%-   set manage_group = False %}
+{%- else %}
+{%-   set manage_group = True %}
+openvpn_group:
+  group.present:
+    - name: {{ map.group }}
+    - require_in:
+      - file: openvpn_config_dir
+      - sls: openvpn.config
+{%- endif %}
+
+{%- if not (map.manage_user is sameas false or map.user == 'nobody') %}
+openvpn_user:
+  user.present:
+    - name: {{ map.user }}
+    - gid: {{ map.group }}
+{%-   if manage_group %}
+    - require:
+      - group: openvpn_group
+{%-   endif %}
+    - require_in:
+      - file: openvpn_config_dir
+      - sls: openvpn.config
+{%- endif %}
+
 openvpn_config_dir:
   file.directory:
     - name: {{ map.conf_dir }}

--- a/openvpn/general_config.sls
+++ b/openvpn/general_config.sls
@@ -1,0 +1,13 @@
+{# This SLS serves only as a capsule to ease handling of dependencies. #}
+
+{% from "openvpn/map.jinja" import map with context %}
+
+openvpn_config_dir:
+  file.directory:
+    - name: {{ map.conf_dir }}
+    - mode: 750
+    - user: {{ map.user }}
+    - group: {{ map.group }}
+    - require_in:
+      - sls: openvpn.config
+

--- a/openvpn/osfamilymap.yaml
+++ b/openvpn/osfamilymap.yaml
@@ -7,6 +7,8 @@ FreeBSD:
   group: openvpn
   multi_services: True
   user: openvpn
+  manage_user: False
+  manage_group: False
 Windows:
   conf_dir: C:\Program Files\OpenVPN\config
   conf_ext: ovpn

--- a/pillar.example
+++ b/pillar.example
@@ -23,6 +23,31 @@
 #                                     # Info here: https://community.openvpn.net/openvpn/wiki/OpenvpnSoftwareRepos
 #                                     # Valid options: stable (default), testing, release/2.3, release/2.4
 
+
+##
+# OpenVPN user and group
+#
+# For historic reasons these are the default values:
+#openvpn:
+#  lookup:
+#    user: nobody
+#    group: nobody  # nogroup on Debian
+
+# You should change them in order to prevent other members of 'nobody'
+# (resp. 'nogroup') to view OpenVPN's config.
+
+openvpn:
+  lookup:
+    user: openvpn
+    group: openvpn
+    # When the user is not 'nobody', it will be managed by this formula.
+    # You can suppress this by: (Default on FreeBSD)
+    manage_user: False
+    # When the group is neither 'nobody' nor 'nogroup',
+    # it will be managed by this formula.
+    # You can suppress this by: (Default on FreeBSD)
+    manage_group: False
+
 openvpn:
   server:
     myserver1:


### PR DESCRIPTION
I was wondering why my `client-config-dir` option had no effect. Turns out OpenVPN is already non-privileged when it accesses this directory. That led to a rat's tail of smaller changes. :-)

- Config is now owned by `root`. (There's no reason for it to be editable by the OpenVPN process.)
- Config is now only readable by the OpenVPN process' group. (To prevent other local users from leaking information.)
- `/etc/openvpn` is now managed.
- If the user is not `nobody`, it gets managed. (Opt-out via `manage_user: False`)
- If the group is neither `nobody` nor `nogroup`, it gets managed. (Opt-out via `manage_group: False`)

[edit]

Tested on
- Debian 9.5
- FreeBSD 11.2. 

[/edit]