### PR TITLE
network_manager_networks: support OpenVPN's 'proto: tcp-client'

### DIFF
--- a/openvpn/network_manager_networks/files/connection.jinja
+++ b/openvpn/network_manager_networks/files/connection.jinja
@@ -78,7 +78,7 @@ comp-lzo={{ vpn_data.pop('comp_lzo') }}
 cert-pass-flags=1
 {%-       endif -%}
 
-{%-       if vpn_data.pop('proto', 'udp') == 'tcp' %}
+{%-       if vpn_data.pop('proto', 'udp') in ['tcp', 'tcp-client'] %}
 proto-tcp=yes
 {%-       endif -%}
 


### PR DESCRIPTION
Tested on Ubuntu 18.04 with OpenVPN 2.4.6.