### PR TITLE
Debianize service name

### DIFF
--- a/openvpn/service.sls
+++ b/openvpn/service.sls
@@ -12,7 +12,7 @@
 
 # How to name the service (instance)?
 {% if salt['grains.has_value']('systemd') %}
-{% set service_name = 'openvpn@' ~ name %}
+{% set service_name = 'openvpn-' ~ type ~ '@' ~ name %}
 {% else %}
 {% set service_name = 'openvpn_' ~ name %}
 {% endif %}


### PR DESCRIPTION
In Debian/Ubuntu openvpn systemd unit names are either openvpn-server@[config-name] or openvpn-client@[config-name] not just openvpn@[config-name]