### PR TITLE
fix(freebsd): load if_tap module

### DIFF
--- a/openvpn/general_config.sls
+++ b/openvpn/general_config.sls
@@ -37,3 +37,11 @@ openvpn_config_dir:
     - require_in:
       - sls: openvpn.config
 
+{%- if grains.os_family == 'FreeBSD' %}
+openvpn_kldload_if_tap:
+  kmod.present:
+    - name: if_tap
+    - persist: True
+    - require_in:
+      - sls: openvpn.config
+{%- endif %}


### PR DESCRIPTION
Tested on FreeBSD 11.2 with Salt 2019.2.0.

Without `if_tap` loaded OpenVPN can't bring up tun/tap devices.