### PR TITLE
fix(config): set tls-auth and tls-crypt independently of ta_content

### DIFF
--- a/openvpn/files/common_opts.jinja
+++ b/openvpn/files/common_opts.jinja
@@ -179,9 +179,9 @@ dh {{ config.dh }}
 dh dh1024.pem
 {%- endif %}
 
-{%- if config.ta_content is defined and config.tls_crypt is defined %}
+{%- if config.tls_crypt is defined %}
 tls-crypt {{ config.tls_crypt }}
-{%- elif config.ta_content is defined and config.tls_auth is defined %}
+{%- elif config.tls_auth is defined %}
 tls-auth {{ multipart_param(config.tls_auth) }}
 {%- endif %}
 


### PR DESCRIPTION
I've got a case where the TA key is generated independently of the formula, but `tls-auth` shall be set nonetheless.

This patch decouples `ta_content` and `tls_auth`/`tls_crypt`.

Tested on Ubuntu 18.04 and FreeBSD 11.2.