### PR TITLE
fix(config): Debian/Ubuntu distinguishes between service and client

### DIFF
--- a/openvpn/config.sls
+++ b/openvpn/config.sls
@@ -24,7 +24,7 @@ include:
 {%-   set config_dir = config.conf_dir %}
 {%- else %}
 {#-   Some distributions use /etc/openvpn/{client,server} as their working directory #}
-{%-   set config_dir = map.get(type ~ "_conf_dir", map.conf_dir) %}
+{%-   set config_dir = map.get(type, {}).get("conf_dir", map.conf_dir) %}
 {%- endif %}
 
 {% set config_file = "{0}/openvpn_{1}.conf".format(config_dir, name) if map.multi_services and grains['os_family'] == 'FreeBSD' else "{0}/{1}.{2}".format(config_dir, name, map.conf_ext) %}

--- a/openvpn/config.sls
+++ b/openvpn/config.sls
@@ -19,10 +19,12 @@ include:
 
 {% set service_id = "openvpn_{0}_service".format(name) if map.multi_services else "openvpn_service" %}
 
-{%- set config_dir = config.conf_dir if config.conf_dir is defined else map.conf_dir %}
-{%- if grains.os == "Fedora" %}
-{#-   Fedora uses /etc/openvpn/{client,server} as their working directory #}
-{%-   set config_dir = config_dir ~ '/' ~ type %}
+{%- if config.conf_dir is defined %}
+{#-   Use the explicit config from Pillar, if it is present. #}
+{%-   set config_dir = config.conf_dir %}
+{%- else %}
+{#-   Some distributions use /etc/openvpn/{client,server} as their working directory #}
+{%-   set config_dir = map.get(type ~ "_conf_dir", map.conf_dir) %}
 {%- endif %}
 
 {% set config_file = "{0}/openvpn_{1}.conf".format(config_dir, name) if map.multi_services and grains['os_family'] == 'FreeBSD' else "{0}/{1}.{2}".format(config_dir, name, map.conf_ext) %}

--- a/openvpn/dhparams.sls
+++ b/openvpn/dhparams.sls
@@ -3,7 +3,7 @@
 # Generate diffie hellman files
 {% if salt['pillar.get']('openvpn:server', False) %}
   {#- Some distributions use /etc/openvpn/{client,server} as their working directory #}
-  {%- set config_dir = map.get("server_conf_dir", map.conf_dir) %}
+  {%- set config_dir = map.get("server", {}).get("conf_dir", map.conf_dir) %}
   {%- for dh in map.dh_files %}
     {%- set dh_file = config_dir ~ "/dh" ~ dh ~ ".pem" %}
 openvpn_create_dh_{{ dh }}:

--- a/openvpn/dhparams.sls
+++ b/openvpn/dhparams.sls
@@ -2,11 +2,14 @@
 
 # Generate diffie hellman files
 {% if salt['pillar.get']('openvpn:server', False) %}
+  {#- Some distributions use /etc/openvpn/{client,server} as their working directory #}
+  {%- set config_dir = map.get("server_conf_dir", map.conf_dir) %}
   {%- for dh in map.dh_files %}
+    {%- set dh_file = config_dir ~ "/dh" ~ dh ~ ".pem" %}
 openvpn_create_dh_{{ dh }}:
   cmd.run:
-    - name: openssl dhparam {% if map.dsaparam %}-dsaparam {% endif %}-out {{ map.conf_dir }}/dh{{ dh }}.pem {{ dh }}
-    - creates: {{ map.conf_dir }}/dh{{ dh }}.pem
+    - name: openssl dhparam {% if map.dsaparam %}-dsaparam {% endif %}-out {{ dh_file }} {{ dh }}
+    - creates: {{ dh_file }}
     - require:
       - pkg: openvpn_pkgs
   {%- endfor %}

--- a/openvpn/osfamilymap.yaml
+++ b/openvpn/osfamilymap.yaml
@@ -8,6 +8,10 @@ Arch:
 Debian:
   group: nogroup
   log_user: root
+  client_conf_dir: /etc/openvpn/client
+  client_service: openvpn-client
+  server_conf_dir: /etc/openvpn/server
+  server_service: openvpn-server
 RedHat:
   pkgs:
     - openvpn

--- a/openvpn/osfamilymap.yaml
+++ b/openvpn/osfamilymap.yaml
@@ -8,10 +8,12 @@ Arch:
 Debian:
   group: nogroup
   log_user: root
-  client_conf_dir: /etc/openvpn/client
-  client_service: openvpn-client
-  server_conf_dir: /etc/openvpn/server
-  server_service: openvpn-server
+  client:
+    conf_dir: /etc/openvpn/client
+    service: openvpn-client
+  server:
+    conf_dir: /etc/openvpn/server
+    service: openvpn-server
 RedHat:
   pkgs:
     - openvpn

--- a/openvpn/osmap.yaml
+++ b/openvpn/osmap.yaml
@@ -6,6 +6,11 @@ Debian:
     - wheezy
     - jessie
     - stretch
+Fedora:
+  client_conf_dir: /etc/openvpn/client
+  client_service: openvpn-client
+  server_conf_dir: /etc/openvpn/server
+  server_service: openvpn-server
 Ubuntu:
   external_repo_supported:
     - precise

--- a/openvpn/osmap.yaml
+++ b/openvpn/osmap.yaml
@@ -7,10 +7,12 @@ Debian:
     - jessie
     - stretch
 Fedora:
-  client_conf_dir: /etc/openvpn/client
-  client_service: openvpn-client
-  server_conf_dir: /etc/openvpn/server
-  server_service: openvpn-server
+  client:
+    conf_dir: /etc/openvpn/client
+    service: openvpn-client
+  server:
+    conf_dir: /etc/openvpn/server
+    service: openvpn-server
 Ubuntu:
   external_repo_supported:
     - precise

--- a/openvpn/service.sls
+++ b/openvpn/service.sls
@@ -12,7 +12,7 @@
 
 # How to name the service (instance)?
 {% if salt['grains.has_value']('systemd') %}
-{#-   
+{#-
    Some distributions use /etc/openvpn/{client,server} as their working directory
    and openvpn-{client,server} as their service.
 #}

--- a/openvpn/service.sls
+++ b/openvpn/service.sls
@@ -17,6 +17,14 @@
    and openvpn-{client,server} as their service.
 #}
 {% set service_name = map.get(type, {}).get("service", map.service) ~ '@' ~ name %}
+{#-
+   For an successful upgrade we need to make sure the old services are deactivated.
+   This affects at least Debian.
+#}
+obsolete_openvpn_{{ name }}_service:
+  service.dead:
+    - name: {{ map.service ~ '@' ~ name }}
+    - enable: False
 {% else %}
 {% set service_name = map.service ~ '_' ~ name %}
 {% endif %}

--- a/openvpn/service.sls
+++ b/openvpn/service.sls
@@ -12,12 +12,11 @@
 
 # How to name the service (instance)?
 {% if salt['grains.has_value']('systemd') %}
-{%-   if grains.os == "Fedora" %}
-{#-     Fedora uses /etc/openvpn/{client,server} as their working directory #}
-{%      set service_name = map.service ~ '-' ~ type ~ '@' ~ name %}
-{%-   else %}
-{%      set service_name = map.service ~ '@' ~ name %}
-{%-   endif %}
+{#-   
+   Some distributions use /etc/openvpn/{client,server} as their working directory
+   and openvpn-{client,server} as their service.
+#}
+{% set service_name = map.get(type ~ "_service", map.service) ~ '@' ~ name %}
 {% else %}
 {% set service_name = map.service ~ '_' ~ name %}
 {% endif %}

--- a/openvpn/service.sls
+++ b/openvpn/service.sls
@@ -16,7 +16,7 @@
    Some distributions use /etc/openvpn/{client,server} as their working directory
    and openvpn-{client,server} as their service.
 #}
-{% set service_name = map.get(type ~ "_service", map.service) ~ '@' ~ name %}
+{% set service_name = map.get(type, {}).get("service", map.service) ~ '@' ~ name %}
 {% else %}
 {% set service_name = map.service ~ '_' ~ name %}
 {% endif %}

--- a/test/integration/default/controls/config_spec.rb
+++ b/test/integration/default/controls/config_spec.rb
@@ -7,7 +7,11 @@ control 'OpenVPN server configuration' do
 
   cfgfile =
     case os[:name]
+    when 'debian' then
+      '/etc/openvpn/server/myserver1.conf'
     when 'fedora' then
+      '/etc/openvpn/server/myserver1.conf'
+    when 'ubuntu' then
       '/etc/openvpn/server/myserver1.conf'
     else
       '/etc/openvpn/myserver1.conf'
@@ -23,7 +27,7 @@ control 'OpenVPN server configuration' do
     its('content') { should include 'user' }
   end
 
-  describe command('ls -l /etc/openvpn/myserver1.conf') do
+  describe command("ls -l #{cfgfile}") do
     its('stdout') { should include " #{user} #{group} " }
   end
 end
@@ -33,7 +37,11 @@ control 'OpenVPN client configuration' do
 
   cfgfile =
     case os[:name]
+    when 'debian' then
+      '/etc/openvpn/client/myclient1.conf'
     when 'fedora' then
+      '/etc/openvpn/client/myclient1.conf'
+    when 'ubuntu' then
       '/etc/openvpn/client/myclient1.conf'
     else
       '/etc/openvpn/myclient1.conf'
@@ -49,7 +57,7 @@ control 'OpenVPN client configuration' do
     its('content') { should include 'user' }
   end
 
-  describe command('ls -l /etc/openvpn/myclient1.conf') do
+  describe command("ls -l #{cfgfile}") do
     its('stdout') { should include " #{user} #{group} " }
   end
 end

--- a/test/integration/default/controls/config_spec.rb
+++ b/test/integration/default/controls/config_spec.rb
@@ -7,11 +7,11 @@ control 'OpenVPN server configuration' do
 
   cfgfile =
     case os[:name]
-    when 'debian' then
+    when 'debian'
       '/etc/openvpn/server/myserver1.conf'
-    when 'fedora' then
+    when 'fedora'
       '/etc/openvpn/server/myserver1.conf'
-    when 'ubuntu' then
+    when 'ubuntu'
       '/etc/openvpn/server/myserver1.conf'
     else
       '/etc/openvpn/myserver1.conf'
@@ -37,11 +37,11 @@ control 'OpenVPN client configuration' do
 
   cfgfile =
     case os[:name]
-    when 'debian' then
+    when 'debian'
       '/etc/openvpn/client/myclient1.conf'
-    when 'fedora' then
+    when 'fedora'
       '/etc/openvpn/client/myclient1.conf'
-    when 'ubuntu' then
+    when 'ubuntu'
       '/etc/openvpn/client/myclient1.conf'
     else
       '/etc/openvpn/myclient1.conf'

--- a/test/integration/default/controls/config_spec.rb
+++ b/test/integration/default/controls/config_spec.rb
@@ -26,10 +26,6 @@ control 'OpenVPN server configuration' do
     its('content') { should include '# Managed by Salt' }
     its('content') { should include 'user' }
   end
-
-  describe command("ls -l #{cfgfile}") do
-    its('stdout') { should include " #{user} #{group} " }
-  end
 end
 
 control 'OpenVPN client configuration' do
@@ -55,9 +51,5 @@ control 'OpenVPN client configuration' do
     its('content') { should include '# OpenVPN client configuration' }
     its('content') { should include '# Managed by Salt' }
     its('content') { should include 'user' }
-  end
-
-  describe command("ls -l #{cfgfile}") do
-    its('stdout') { should include " #{user} #{group} " }
   end
 end

--- a/test/integration/default/controls/services_spec.rb
+++ b/test/integration/default/controls/services_spec.rb
@@ -15,7 +15,11 @@ control 'OpenVPN service' do
 
       prefix =
         case os[:name]
+        when 'debian' then
+          "openvpn-#{role}"
         when 'fedora' then
+          "openvpn-#{role}"
+        when 'ubuntu' then
           "openvpn-#{role}"
         else
           'openvpn'

--- a/test/integration/default/controls/services_spec.rb
+++ b/test/integration/default/controls/services_spec.rb
@@ -15,11 +15,11 @@ control 'OpenVPN service' do
 
       prefix =
         case os[:name]
-        when 'debian' then
+        when 'debian'
           "openvpn-#{role}"
-        when 'fedora' then
+        when 'fedora'
           "openvpn-#{role}"
-        when 'ubuntu' then
+        when 'ubuntu'
           "openvpn-#{role}"
         else
           'openvpn'

--- a/test/integration/repositories/pillars.sls
+++ b/test/integration/repositories/pillars.sls
@@ -19,6 +19,7 @@ openvpn:
       comp_lzo: "yes"
       ifconfig: 169.254.0.1 169.254.0.2
       log_append: /var/log/openvpn/myserver1.log
+      status: /var/log/openvpn/myserver1-status.log
       secret: /etc/openvpn/myserver1_secret.key
       # /usr/sbin/openvpn --genkey --secret /dev/stdout
       secret_content: |
@@ -56,6 +57,7 @@ openvpn:
       tls_client: false
       nobind: false
       ifconfig: 169.254.0.2 169.254.0.1
+      status: /var/log/openvpn/myclient1-status.log
       log_append: /var/log/openvpn/myclient1.log
       secret: /etc/openvpn/myclient1_secret.key
       # /usr/sbin/openvpn --genkey --secret /dev/stdout


### PR DESCRIPTION
Based on the work of @mortn (#101) and @n-rodriguez (#102).
The idea is to make the distinction between server and client services an opt-in in the `map.jinja` files.
Debian now properly supports this too.

Tested on FreeBSD 11.2 and Debian 10.