### PR TITLE
feat(yamllint): include for this repo and apply rules throughout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 ---
 stages:
   - test
-  - commitlint
+  - lint
   - name: release
     if: branch = master AND type != pull_request
 
@@ -46,16 +46,21 @@ script:
 
 jobs:
   include:
-    # Define the commitlint stage
-    - stage: commitlint
+    # Define the `lint` stage (runs `yamllint` and `commitlint`)
+    - stage: lint
       language: node_js
       node_js: lts/*
       before_install: skip
       script:
+        # Install and run `yamllint`
+        - pip install --user yamllint
+        # yamllint disable-line rule:line-length
+        - yamllint -s . .yamllint pillar.example test/integration/repositories/pillars.sls
+        # Install and run `commitlint`
         - npm install @commitlint/config-conventional -D
         - npm install @commitlint/travis-cli -D
         - commitlint-travis
-    # Define the release stage that runs semantic-release
+    # Define the release stage that runs `semantic-release`
     - stage: release
       language: node_js
       node_js: lts/*

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+# Extend the `default` configuration provided by `yamllint`
+extends: default
+
+# Files to ignore completely
+# 1. All YAML files under directory `node_modules/`, introduced during the Travis run
+ignore: |
+  node_modules/
+
+rules:
+  line-length:
+    # Increase from default of `80`
+    # Based on https://github.com/PyCQA/flake8-bugbear#opinionated-warnings (`B950`)
+    max: 88

--- a/openvpn/defaults.yaml
+++ b/openvpn/defaults.yaml
@@ -1,15 +1,18 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 openvpn:
   conf_dir: /etc/openvpn
   conf_ext: conf
   dh_files: ['2048', '4096']
-  dsaparam: False
-  external_repo_enabled: False
+  dsaparam: false
+  external_repo_enabled: false
   external_repo_supported: []
   external_repo_version: stable
   group: nobody
   # None, will default to 'user'
   log_user:
-  multi_services: False
+  multi_services: false
   pkgs: ['openvpn']
   service: openvpn
   service_function: running

--- a/openvpn/osfamilymap.yaml
+++ b/openvpn/osfamilymap.yaml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 Arch:
   pkgs:
     - openvpn
@@ -12,10 +15,10 @@ RedHat:
 FreeBSD:
   conf_dir: /usr/local/etc/openvpn
   group: openvpn
-  multi_services: True
+  multi_services: true
   user: openvpn
-  manage_user: False
-  manage_group: False
+  manage_user: false
+  manage_group: false
 Windows:
   conf_dir: C:\Program Files\OpenVPN\config
   conf_ext: ovpn

--- a/openvpn/osfingermap.yaml
+++ b/openvpn/osfingermap.yaml
@@ -1,2 +1,5 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 CentOS-6:
   multi_services: false

--- a/openvpn/osmap.yaml
+++ b/openvpn/osmap.yaml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 Debian:
   external_repo_supported:
     - wheezy

--- a/pillar.example
+++ b/pillar.example
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 # See https://openvpn.net/index.php/open-source/documentation/howto.html#examples
 # for configuration details
 # Important: Replace all '-' in names on left side with '_'!
@@ -5,31 +8,37 @@
 # Defaults can be overwritten, see openvpn/map.jinja for default values
 # openvpn:
 #   lookup:
-#     dh_files: ['4096']              # This creates a dh file with 4096 bits (which will take a long time).
-#     dh_files: ['2048']              # This creates a dh file with 2048 bits (which should be enough.)
-#                                     # Default: ['2048', '4096']
-#                                     # (It creates both variants.)
+#     # This creates a dh file with 4096 bits (which will take a long time).
+#     dh_files: ['4096']
+#     # This creates a dh file with 2048 bits (which should be enough.)
+#     # Default: ['2048', '4096']
+#     # (It creates both variants.)
+#     dh_files: ['2048']
 #
-#     dsaparam: False                 # Set this to True if you want to use the -dsaparam flag in DH param generation.
-#                                     # See also:
-#                                     # https://github.com/saltstack-formulas/openvpn-formula/pull/77
-#                                     # https://security.stackexchange.com/questions/42415/openvpn-dhparam
+#     # Set this to true if you want to use the -dsaparam flag in DH param generation.
+#     # See also:
+#     # https://github.com/saltstack-formulas/openvpn-formula/pull/77
+#     # https://security.stackexchange.com/questions/42415/openvpn-dhparam
+#     dsaparam: false
 #
-#     external_repo_enabled: True     # This will use the OpenVPN repository documented
-#                                     # at the following URL: https://community.openvpn.net/openvpn/wiki/OpenvpnSoftwareRepos
-#                                     # Only valid for Debian OS family
+#     # This will use the OpenVPN repository documented
+#     # at the following URL:
+#     # https://community.openvpn.net/openvpn/wiki/OpenvpnSoftwareRepos
+#     # Only valid for Debian OS family
+#     external_repo_enabled: true
 #
-#     external_repo_version: testing  # The version to use for OpenVPN if 'external_repo_enabled' is set to 'True'
-#                                     # Info here: https://community.openvpn.net/openvpn/wiki/OpenvpnSoftwareRepos
-#                                     # Valid options: stable (default), testing, release/2.3, release/2.4
+#     # The version to use for OpenVPN if 'external_repo_enabled' is set to 'true'
+#     # Info here: https://community.openvpn.net/openvpn/wiki/OpenvpnSoftwareRepos
+#     # Valid options: stable (default), testing, release/2.3, release/2.4
+#     external_repo_version: testing
 
-#See also the example used in tests: test/integration/repositories/pillars.sls
+# See also the example used in tests: test/integration/repositories/pillars.sls
 
 ##
 # OpenVPN user and group
 #
 # For historic reasons these are the default values:
-#openvpn:
+# openvpn:
 #  lookup:
 #    user: nobody
 #    group: nobody  # nogroup on Debian
@@ -43,17 +52,16 @@ openvpn:
     group: openvpn
     # When the user is not 'nobody', it will be managed by this formula.
     # You can suppress this by: (Default on FreeBSD)
-    manage_user: False
+    manage_user: false
     # When the group is neither 'nobody' nor 'nogroup',
     # it will be managed by this formula.
     # You can suppress this by: (Default on FreeBSD)
-    manage_group: False
+    manage_group: false
 
     # If you want to control the openvpn services via other tools,
     # you want to 'disabled' it in your system. Default: running
-    #service_function: disabled
+    # service_function: disabled
 
-openvpn:
   server:
     myserver1:
       ca: /path/to/mycacert.pem
@@ -100,7 +108,7 @@ openvpn:
       # tl;dr: The bigger, the better.
       dh: dh4096.pem
       # for faster DP params generation use only ['2048'] in openvpn:lookup:dh_files
-      #dh: dh2048.pem
+      # dh: dh2048.pem
       server: '10.8.0.0 255.255.255.0'
       ifconfig_pool_persist: ipp.txt
       server_bridge:
@@ -114,8 +122,8 @@ openvpn:
         client1: |
           iroute 192.168.10.0 255.255.255.0
       learn_address:
-      client_to_client: False
-      duplicate_cn: False
+      client_to_client: false
+      duplicate_cn: false
       keepalive: '10 120'
       # `tls-auth` and `tls-crypt` are mutually exclusive
       # and `tls-crypt` is only valid for OpenVPN 2.4 and above.
@@ -133,6 +141,7 @@ openvpn:
         - AES-256-CBC
       auths:
         - SHA384
+      # yamllint disable-line rule:line-length
       tls_cipher: 'DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-CAMELLIA256-SHA:DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA128-SHA:DHE-RSA-AES128-SHA:CAMELLIA256-SHA:AES256-SHA:CAMELLIA128-SHA:AES128-SHA'
       comp_lzo:
       max_clients: 100
@@ -162,9 +171,9 @@ openvpn:
       ifconfig: '10.8.0.1 10.8.0.2'
       secret: /path/to/mysecret.key
       # or
-      #secret: /path/to/mysecret.key 0
+      # secret: /path/to/mysecret.key 0
       # or
-      #secret:  # use this form for paths with spaces
+      # secret:  # use this form for paths with spaces
       #  - /path/to/mysecret.key
       #  - 0
       secret_content: |
@@ -211,13 +220,11 @@ openvpn:
       http_proxy_retry:
       http_proxy: 'proxy-server proxy-port'
       mute_replay_warnings:
-{% if grains['os_family'] == 'Windows' %}
-      dev_node: ovpn-myclient2
-      # Take care with the quoting for Windows paths with spaces
-      ca: '"C:\\Program Files\\OpenVPN\\config\\mycacert.pem"'
-{% else %}
       ca: /path/to/mycacert.pem
-{% endif %}
+      # The following two commented options are examples for Windows
+      # dev_node: ovpn-myclient2
+      # Take care with the quoting for Windows paths with spaces
+      # ca: '"C:\\Program Files\\OpenVPN\\config\\mycacert.pem"'
       ca_content: |
         -----BEGIN CERTIFICATE-----
         ...
@@ -236,7 +243,7 @@ openvpn:
       askpass_content: |
         p4ssw0rd
       ns_cert_type: server
-      #tls_auth: /path/to/tls.key 0
+      # tls_auth: /path/to/tls.key 0
       # or:
       tls_auth:  # use this form for paths with spaces
         - /path/to/tls.key
@@ -250,6 +257,7 @@ openvpn:
         - AES-256-CBC
       auths:
         - SHA384
+      # yamllint disable-line rule:line-length
       tls_cipher: 'DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-CAMELLIA256-SHA:DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA128-SHA:DHE-RSA-AES128-SHA:CAMELLIA256-SHA:AES256-SHA:CAMELLIA128-SHA:AES128-SHA'
       remote_cert_tls: server
       comp_lzo:
@@ -257,9 +265,9 @@ openvpn:
       mute: 20
       up: /usr/local/bin/tunnel_up.sh
       down: /usr/local/bin/tunnel_down.sh
-      up_delay: True
-      down_pre: True
-      up_restart: True
+      up_delay: true
+      down_pre: true
+      up_restart: true
       _append:
         - script-security 2
         - up 'echo up'
@@ -283,12 +291,12 @@ openvpn:
       route:
         - "8.8.8.8 255.255.255.255 net_gateway"
     myclient3:
-      pull: False
+      pull: false
       # from the man page:
       # This option must be used on a client which is connecting to a
       # multi-client server. It indicates to OpenVPN that it should accept
       # options pushed by the server, provided they are part of the legal
-      # set of pushable options 
+      # set of pushable options
 
   ifconfig_pool_persist:
     ipp.txt:
@@ -301,7 +309,7 @@ openvpn:
 
   ##
   # Use latest OpenVPN packages (default: false)
-  use_latest: False
+  use_latest: false
 
   # Managing clients which use NetworkManager
   # (Intentionally does not handle certificate/key distribution!)

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 name: default
 title: openvpn formula
 maintainer: SaltStack Formulas

--- a/test/integration/repositories/pillars.sls
+++ b/test/integration/repositories/pillars.sls
@@ -1,10 +1,13 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 openvpn:
   lookup:
     user: openvpn
     group: openvpn
-    manage_user: True
-    manage_group: True
-    external_repo_enabled: True
+    manage_user: true
+    manage_group: true
+    external_repo_enabled: true
     dh_files: ['512']
   server:
     myserver1:
@@ -49,9 +52,9 @@ openvpn:
       topology: p2p
       dev: tun
       comp_lzo: "yes"
-      pull: False
-      tls_client: False
-      nobind: False
+      pull: false
+      tls_client: false
+      nobind: false
       ifconfig: 169.254.0.2 169.254.0.1
       log_append: /var/log/openvpn/myclient1.log
       secret: /etc/openvpn/myclient1_secret.key
@@ -78,4 +81,3 @@ openvpn:
         4c099bf8e74b8bf4e6509de69b7a79ad
         7391b6cf3f4ae296ecf8b552144a2947
         -----END OpenVPN Static key V1-----
-


### PR DESCRIPTION
* Semi-automated using `ssf-formula` (v0.5.0)
* Fix errors shown below:

```bash
openvpn-formula$ $(grep "\- yamllint" .travis.yml | sed -e "s:^\s\+-\s\(.*\):\1:")
./openvpn/osfamilymap.yaml
  1:1       warning  missing document start "---"  (document-start)
  15:19     warning  truthy value should be one of [false, true]  (truthy)
  17:16     warning  truthy value should be one of [false, true]  (truthy)
  18:17     warning  truthy value should be one of [false, true]  (truthy)

./openvpn/defaults.yaml
  1:1       warning  missing document start "---"  (document-start)
  5:13      warning  truthy value should be one of [false, true]  (truthy)
  6:26      warning  truthy value should be one of [false, true]  (truthy)
  12:19     warning  truthy value should be one of [false, true]  (truthy)

./openvpn/osmap.yaml
  1:1       warning  missing document start "---"  (document-start)

./openvpn/osfingermap.yaml
  1:1       warning  missing document start "---"  (document-start)

pillar.example
  8:89      error    line too long (108 > 88 characters)  (line-length)
  9:89      error    line too long (103 > 88 characters)  (line-length)
  13:89     error    line too long (118 > 88 characters)  (line-length)
  15:89     error    line too long (101 > 88 characters)  (line-length)
  16:89     error    line too long (106 > 88 characters)  (line-length)
  19:89     error    line too long (125 > 88 characters)  (line-length)
  22:89     error    line too long (114 > 88 characters)  (line-length)
  23:89     error    line too long (114 > 88 characters)  (line-length)
  24:89     error    line too long (106 > 88 characters)  (line-length)
  26:2      warning  missing starting space in comment  (comments)
  32:2      warning  missing starting space in comment  (comments)
  40:1      warning  missing document start "---"  (document-start)
  46:18     warning  truthy value should be one of [false, true]  (truthy)
  50:19     warning  truthy value should be one of [false, true]  (truthy)
  54:6      warning  missing starting space in comment  (comments)
  56:1      error    duplication of key "openvpn" in mapping  (key-duplicates)
  103:8     warning  missing starting space in comment  (comments)
  117:25    warning  truthy value should be one of [false, true]  (truthy)
  118:21    warning  truthy value should be one of [false, true]  (truthy)
  136:89    error    line too long (255 > 88 characters)  (line-length)
  165:8     warning  missing starting space in comment  (comments)
  167:8     warning  missing starting space in comment  (comments)
  214:2     error    syntax error: found character '%' that cannot start any token
  253:89    error    line too long (255 > 88 characters)  (line-length)
  291:32    error    trailing spaces  (trailing-spaces)

test/integration/repositories/pillars.sls
  1:1       warning  missing document start "---"  (document-start)
  5:18      warning  truthy value should be one of [false, true]  (truthy)
  6:19      warning  truthy value should be one of [false, true]  (truthy)
  7:28      warning  truthy value should be one of [false, true]  (truthy)
  52:13     warning  truthy value should be one of [false, true]  (truthy)
  53:19     warning  truthy value should be one of [false, true]  (truthy)
  54:15     warning  truthy value should be one of [false, true]  (truthy)
  81:1      error    too many blank lines (1 > 0)  (empty-lines)
```

---

Refer back to: https://github.com/saltstack-formulas/template-formula/pull/159#issue-305203039.