### PR TITLE
Fix comp-lzo setting

### DIFF
--- a/openvpn/files/common_opts.jinja
+++ b/openvpn/files/common_opts.jinja
@@ -112,8 +112,8 @@ persist-tun
 ; Data transfer
 {%- if config.comp_lzo is defined and config.comp_lzo == False %}
 comp-lzo no
-{%- elif config.comp_lzo is defined %}
-comp-lzo {{ config.comp_lzo }}
+{%- elif config.comp_lzo is defined and config.comp_lzo == True %}
+comp-lzo yes
 {%- endif %}
 
 


### PR DESCRIPTION
I was ending up with `comp-lzo True` in my config files - even
when it was set to `yes` in Pillar. I guess the Yaml to JSON
conversion changed the value. This fixes it for me.